### PR TITLE
sparkler/github: don't skip releases without "-"

### DIFF
--- a/util/sparkler/lib/github.ts
+++ b/util/sparkler/lib/github.ts
@@ -126,11 +126,6 @@ export const getReleases = async (): Promise<Release[]> => {
     const reformattedReleases: Release[] = [];
 
     for (const ghRelease of githubReleases) {
-        // pre-helium versioning releases
-        if (!ghRelease.tag_name.includes('-')) {
-            continue;
-        }
-
         const version = ghRelease.tag_name.split('-')[0];
         const release: Release = {
             version,


### PR DESCRIPTION
old tags and releases have been cleaned up & we switched to version tagging without "-", aka "0.3.5.1" instead of "0.3.5.1-139.0.7258.138"