### PR TITLE
svc/nginx: drop dhparam and associated setup

### DIFF
--- a/svc/nginx/Dockerfile
+++ b/svc/nginx/Dockerfile
@@ -15,7 +15,6 @@ ARG SERVICES_HOSTNAME
 ENV SERVICES_HOSTNAME "$SERVICES_HOSTNAME"
 
 RUN apk add --no-cache inotify-tools curl
-RUN curl https://ssl-config.mozilla.org/ffdhe4096.txt -o /etc/nginx/dhparam.pem
 
 COPY --from=prep /*.conf /etc/nginx/
 COPY --from=prep /assets.json /usr/share/ublock/ubo/

--- a/svc/nginx/nginx.conf.j2
+++ b/svc/nginx/nginx.conf.j2
@@ -25,7 +25,6 @@ http {
     ssl_protocols TLSv1.3;
     ssl_ecdh_curve X25519:prime256v1:secp384r1;
     ssl_prefer_server_ciphers on;
-    ssl_dhparam /etc/nginx/dhparam.pem;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 1d;
     ssl_session_tickets off;


### PR DESCRIPTION
since we are using TLSv1.3 exclusively, the dhparam setting is effectively a no-op, so let's just drop it