### PR TITLE
Add new alias to ChatGPT bang

### DIFF
--- a/svc/bangs/bangs.json
+++ b/svc/bangs/bangs.json
@@ -42121,8 +42121,8 @@
  {
   "s": "ChatGPT",
   "ts": [ 
-    "chatgpt",
-    "cgpt"
+   "chatgpt",
+   "cgpt"
   ],
   "u": "https://chatgpt.com/?q={searchTerms}",
   "sc": "ai"

--- a/svc/bangs/bangs.json
+++ b/svc/bangs/bangs.json
@@ -42120,7 +42120,10 @@
  },
  {
   "s": "ChatGPT",
-  "ts": [ "chatgpt" ],
+  "ts": [ 
+    "chatgpt",
+    "cgpt"
+  ],
   "u": "https://chatgpt.com/?q={searchTerms}",
   "sc": "ai"
  },


### PR DESCRIPTION
Hi! 👋

Many of us regularly use the custom site search for ChatGPT. The common shortcut would be gpt, but since that’s already mapped to Google Portugal, I’ve added a new alias: cgpt.

This should make it quicker and easier to search ChatGPT without conflicting with existing shortcuts.

It’s a small change, but it could be a nice quality-of-life improvement for those of us who use it often. If it makes sense to merge, that would be awesome! If not, no worries at all.

Thanks!