### PR TITLE
svc/ubo: cache assets.json forever

### DIFF
--- a/svc/ubo/lib/ublock.ts
+++ b/svc/ubo/lib/ublock.ts
@@ -62,12 +62,8 @@ const prepareAssetString = async () => {
         }
 
         const filename = (() => {
-            if (id.includes('.')) {
-                return id;
-            }
-
             const fn = Path.basename(new URL(sourceURLs[0]).pathname);
-            if (fn.endsWith('.txt')) {
+            if (fn.endsWith('.txt') || fn.endsWith('.dat')) {
                 return fn;
             }
 


### PR DESCRIPTION
assets.json is pinned by SHA256 hash, so the only way it could possibly change is if the code is updated to a new asset list.

so it makes no sense to purge it from cache periodically.