### PR TITLE
Revert "svc, util/sparkler: absolute urls"

### DIFF
--- a/svc/nginx/nginx.conf.j2
+++ b/svc/nginx/nginx.conf.j2
@@ -113,10 +113,6 @@ http {
 
         location /updates/mac {
             proxy_pass https://updates.helium.computer/mac;
-            sub_filter "https://updates.helium.computer/" "https://{{ services_hostname }}/updates/";
-            sub_filter_once off;
-            sub_filter_types text/xml;
-            proxy_set_header Accept-Encoding "";
         }
 
         location /dict {

--- a/util/sparkler/.env.example
+++ b/util/sparkler/.env.example
@@ -2,4 +2,3 @@ GITHUB_REPO=imputnet/helium-macos
 ASSETS_DIR=/tmp/assets
 ED_PRIVATE_KEY=bWFrZSB5b3VyIG93bg==
 APPCAST_PUBLIC_DIR=/tmp/appcasts
-URL_PREFIX=https://updates.helium.computer/mac/

--- a/util/sparkler/lib/appcast.ts
+++ b/util/sparkler/lib/appcast.ts
@@ -12,7 +12,7 @@ import { basename } from 'jsr:@std/path';
 
 const getUrlForAsset = (asset: Asset) => {
     if (env.shouldServeAssets) {
-        return (env.urlPrefix ?? '') + `assets/${asset.name}`;
+        return `assets/${asset.name}`;
     }
 
     return asset.user_facing_url;

--- a/util/sparkler/lib/env.ts
+++ b/util/sparkler/lib/env.ts
@@ -19,7 +19,6 @@ export const env = {
     edSigningKey: strictGet('ED_PRIVATE_KEY'),
     appcastDirectory: strictGet('APPCAST_PUBLIC_DIR'),
     shouldServeAssets: getBool('SERVE_ASSETS_LOCALLY'),
-    urlPrefix: Deno.env.get('URL_PREFIX'),
 };
 
 export const headers: Record<string, string> = {};


### PR DESCRIPTION
the latest update includes deltas only up to helium 0.4.11, which already has support for relative deltas urls, so we can now safely remove this logic entirely

This reverts commit 3655c7853100d58d53773e1b78d9bf0506e8bcce.