### PR TITLE
change roblox experiences to roblox games

### DIFF
--- a/svc/bangs/bangs.json
+++ b/svc/bangs/bangs.json
@@ -25440,7 +25440,7 @@
   "u": "https://ph.rs-online.com/web/c/?searchTerm={searchTerms}"
  },
  {
-  "s": "Roblox Experiences",
+  "s": "Roblox Games",
   "ts": [
    "rspt",
    "roblox",


### PR DESCRIPTION
roblox recently renamed experiences back to games. the bang does not reflect this.