### PR TITLE
svc/minidumpster: improve data hygiene and harden ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ deploy/hosts.yml
 # compose override file
 compose.override.yml
 !deploy/**/compose.override.yml
+
+# minidumpster runtime data contains sensitive crash reports
+svc/minidumpster/data/

--- a/svc/minidumpster/Dockerfile
+++ b/svc/minidumpster/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ARG SYMSORTER_VERSION=26.6.0
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 RUN arch="x86_64"; [ "$TARGETARCH" = "arm64" ] && arch="aarch64"; \
   curl -fsSL -o /usr/local/bin/symsorter \
   "https://github.com/getsentry/symbolicator/releases/download/${SYMSORTER_VERSION}/symsorter-Linux-${arch}" \

--- a/svc/minidumpster/README.md
+++ b/svc/minidumpster/README.md
@@ -1,7 +1,8 @@
 # minidumpster
 
 Crash reporting handler used by Helium for Crashpad minidump uploads, hosted on
-https://crash.helium.computer.
+https://crash.helium.computer. Reports are symbolicated with
+[@getsentry/symbolicator].
 
 ### privacy policy
 
@@ -13,10 +14,9 @@ process memory, they may unintentionally contain personal or otherwise sensitive
 data.
 
 crash reports are used only to diagnose and group Helium crashes. raw reports
-are kept for 30 days by default, after which they are deleted. derived metadata
-and symbolicated stack traces may be retained for longer so regressions can be
-tracked across releases. access to reports is restricted to active members of
-the imputnet GitHub organization.
+and derived report data are kept for 30 days by default, after which they are
+automatically deleted. access to reports is restricted to active members of the
+imputnet GitHub organization.
 
 client IP addresses are used temporarily for rate limiting and are not stored by
 this service. logs contain report identifiers and technical build or processing
@@ -26,11 +26,14 @@ information, but do not contain crash dumps or arbitrary crash annotations.
 
 ```sh
 cp .env.example .env
-# fill in all required field (see inline comments for help)
+# fill in all required fields (see inline comments for help)
 
 mkdir -p data
 docker compose up -d --build
 ```
+
+the crash endpoint uses the first `X-Forwarded-For` address for rate limiting,
+so the reverse proxy must overwrite that header.
 
 ## usage
 

--- a/svc/minidumpster/src/app.ts
+++ b/svc/minidumpster/src/app.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type MiddlewareHandler } from 'hono';
 
 import type { Db } from './db.ts';
 import type { Config } from './config.ts';
@@ -22,8 +22,35 @@ export type Env = {
     };
 };
 
+function securityHeaders(config: Config): MiddlewareHandler<Env> {
+    return async (c, next) => {
+        await next();
+        c.header(
+            'content-security-policy',
+            "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+        );
+        c.header('cross-origin-opener-policy', 'same-origin');
+        c.header('cross-origin-resource-policy', 'same-origin');
+        c.header('referrer-policy', 'no-referrer');
+        c.header('x-content-type-options', 'nosniff');
+        c.header('x-frame-options', 'DENY');
+        if (config.publicBaseUrl.startsWith('https://')) {
+            c.header(
+                'strict-transport-security',
+                'max-age=63072000; includeSubDomains',
+            );
+        }
+    };
+}
+
 export function buildApp(deps: AppDeps): Hono<Env> {
     const app = new Hono<Env>();
+
+    app.use('*', securityHeaders(deps.config));
+    app.use('/auth/*', async (c, next) => {
+        await next();
+        c.header('cache-control', 'no-store');
+    });
 
     app.route('/', Ingest.ingestRoutes(deps));
     app.route('/', Auth.authRoutes(deps));

--- a/svc/minidumpster/src/artifact-crawler.ts
+++ b/svc/minidumpster/src/artifact-crawler.ts
@@ -1,3 +1,5 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
 import type { Config } from './config.ts';
 import type { Db } from './db.ts';
 import { logError, logEvent } from './log.ts';
@@ -9,14 +11,18 @@ import {
     type BuildArtifactKind,
     ingestBuildArtifact,
 } from './build-artifacts.ts';
-import { GithubHttpError, githubHttpError } from './github.ts';
+import {
+    githubApiHeaders,
+    GithubHttpError,
+    githubHttpError,
+} from './github.ts';
 
 const GITHUB_API = 'https://api.github.com';
 const MAX_RELEASES = 10;
 const MAX_ARTIFACT_PAGES = 10;
 const MAX_ATTEMPTS = 5;
 
-export const HELIUM_REPOS = [
+const HELIUM_REPOS = [
     'imputnet/helium-macos',
     'imputnet/helium-windows',
     'imputnet/helium-linux',
@@ -96,15 +102,6 @@ function artifactKind(
     return symbolPattern.test(name) ? 'symbols' : null;
 }
 
-function apiHeaders(token: string): HeadersInit {
-    return {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${token}`,
-        'X-GitHub-Api-Version': '2022-11-28',
-        'User-Agent': 'minidumpster-artifact-crawler',
-    };
-}
-
 async function githubJson<T>(
     fetchFn: typeof fetch,
     url: string,
@@ -112,7 +109,7 @@ async function githubJson<T>(
     signal?: AbortSignal,
 ): Promise<T> {
     const res = await fetchFn(url, {
-        headers: apiHeaders(token),
+        headers: githubApiHeaders(token),
         signal,
     });
     if (!res.ok) {
@@ -247,17 +244,15 @@ async function ingestCandidate(
         );
     } else {
         const download = await fetchFn(artifactUrl, {
-            headers: apiHeaders(token),
+            headers: githubApiHeaders(token),
             redirect: 'follow',
             signal: deps.signal,
         });
-        if (!download.ok || !download.body) {
-            const detail = await download.text().catch(() => '');
-            throw new Error(
-                `artifact download failed: ${download.status} ${
-                    detail.slice(0, 500)
-                }`,
-            );
+        if (!download.ok) {
+            throw await githubHttpError('GitHub artifact download', download);
+        }
+        if (!download.body) {
+            throw new Error('GitHub artifact download returned no body');
         }
         result = await (deps.ingestFn
             ? deps.ingestFn(download.body, 'helium', releaseTag, kind)
@@ -269,9 +264,6 @@ async function ingestCandidate(
                 deps.db,
             ));
     }
-    if (!result.filesExtracted || result.filesExtracted < 1) {
-        throw new Error('symbol upload extracted no files');
-    }
 
     logEvent('artifact_crawler_ingested', {
         repo,
@@ -279,8 +271,8 @@ async function ingestCandidate(
         artifact_id: artifact.id,
         artifact: artifact.name,
         files_extracted: result.filesExtracted,
-        debug_ids: result.debugIds?.length ?? 0,
-        requeued: result.requeued ?? 0,
+        debug_ids: result.debugIds.length,
+        requeued: result.requeued,
     });
 }
 
@@ -394,6 +386,7 @@ export async function crawlArtifactsOnce(
                         });
                         return;
                     }
+
                     const failed = attempts >= MAX_ATTEMPTS;
                     db.markArtifactError(
                         repo,
@@ -426,13 +419,9 @@ export async function crawlArtifactsOnce(
     }
 }
 
-export interface ArtifactCrawlerHandle {
-    stop(): Promise<void>;
-}
-
 export function startArtifactCrawler(
     deps: Omit<ArtifactCrawlerDeps, 'signal'>,
-): ArtifactCrawlerHandle {
+) {
     if (!deps.config.githubArtifactToken) {
         logEvent('artifact_crawler_disabled', {
             reason: 'GITHUB_ARTIFACT_TOKEN is not set',
@@ -440,30 +429,25 @@ export function startArtifactCrawler(
         return { stop: () => Promise.resolve() };
     }
 
-    let stopped = false;
-    let wake: (() => void) | undefined;
-    let timer: ReturnType<typeof setTimeout> | undefined;
     const abort = new AbortController();
+    const { signal } = abort;
     const loop = (async () => {
-        while (!stopped) {
+        while (!signal.aborted) {
             try {
-                await crawlArtifactsOnce({ ...deps, signal: abort.signal });
+                await crawlArtifactsOnce({ ...deps, signal });
             } catch (err) {
-                if (!stopped) {
+                if (!signal.aborted) {
                     logError('artifact_crawler_error', err);
                 }
             }
 
-            if (stopped) {
-                break;
-            }
-
-            await new Promise<void>((resolve) => {
-                wake = resolve;
-                timer = setTimeout(resolve, deps.config.artifactCrawlerPollMs);
+            await delay(
+                deps.config.artifactCrawlerPollMs,
+                undefined,
+                { signal },
+            ).catch((err) => {
+                if (!signal.aborted) throw err;
             });
-            wake = undefined;
-            timer = undefined;
         }
     })();
 
@@ -475,12 +459,9 @@ export function startArtifactCrawler(
     });
 
     return {
-        async stop() {
-            stopped = true;
+        stop() {
             abort.abort();
-            if (timer !== undefined) clearTimeout(timer);
-            wake?.();
-            await loop;
+            return loop;
         },
     };
 }

--- a/svc/minidumpster/src/build-artifacts.ts
+++ b/svc/minidumpster/src/build-artifacts.ts
@@ -1,5 +1,5 @@
 import { basename, join } from '@std/path';
-import { configure, type FileEntry, Reader, ZipReader } from '@zip-js/zip-js';
+import { type FileEntry, Reader, ZipReader } from '@zip-js/zip-js';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
@@ -8,7 +8,7 @@ import { x as extractTar } from 'tar';
 
 import type { Config } from './config.ts';
 import type { Db } from './db.ts';
-import { githubHttpError } from './github.ts';
+import { githubApiHeaders, githubHttpError } from './github.ts';
 import { logEvent } from './log.ts';
 import { tmpDir } from './paths.ts';
 import {
@@ -16,10 +16,13 @@ import {
     type SymbolIngestAndRequeueResult,
     type SymbolsOptions,
 } from './symbols.ts';
-
-configure({ useWebWorkers: false });
+import { DenoFileReader } from './zip.ts';
 
 export type BuildArtifactKind = 'mac-build' | 'windows-build';
+
+const MAX_DOWNLOAD_ATTEMPTS = 5;
+
+class ArtifactSizeMismatchError extends Error {}
 
 function zstdDecompressionStream(): TransformStream<Uint8Array, Uint8Array> {
     let decoder: Decompress;
@@ -37,23 +40,6 @@ function zstdDecompressionStream(): TransformStream<Uint8Array, Uint8Array> {
             decoder.push(new Uint8Array(), true);
         },
     });
-}
-
-class DenoFileReader extends Reader<Deno.FsFile> {
-    constructor(private file: Deno.FsFile) {
-        super(file);
-    }
-
-    override async init(): Promise<void> {
-        this.size = (await this.file.stat()).size;
-    }
-
-    override async readUint8Array(
-        index: number,
-        length: number,
-    ): Promise<Uint8Array> {
-        return await readFileRange(this.file, index, length);
-    }
 }
 
 interface RandomReader {
@@ -74,41 +60,18 @@ class SliceReader extends Reader<null> {
         return Promise.resolve();
     }
 
-    override async readUint8Array(
+    override readUint8Array(
         index: number,
         length: number,
     ): Promise<Uint8Array> {
         if (index < 0 || length < 0 || index + length > this.sliceSize) {
             throw new Error('nested ZIP read is outside the stored entry');
         }
-        return await this.parent.readUint8Array(
+        return this.parent.readUint8Array(
             this.baseOffset + index,
             length,
         );
     }
-}
-
-async function readFileRange(
-    file: Deno.FsFile,
-    index: number,
-    length: number,
-): Promise<Uint8Array> {
-    await file.seek(index, Deno.SeekMode.Start);
-    const buf = new Uint8Array(length);
-    let offset = 0;
-    while (offset < length) {
-        const read = await file.read(buf.subarray(offset));
-        if (read === null) {
-            break;
-        }
-
-        offset += read;
-    }
-    if (offset !== length) {
-        throw new Error('unexpected end of artifact');
-    }
-
-    return buf;
 }
 
 async function countFiles(path: string): Promise<number> {
@@ -139,7 +102,6 @@ async function extractMacBuildReader<T>(
         if (!buildEntry) {
             throw new Error('macOS artifact has no build_src.tar.zst');
         }
-
         const extractor = extractTar({
             cwd: destDir,
             strict: true,
@@ -196,11 +158,9 @@ async function extractWindowsBuildReader<T>(
 ): Promise<number> {
     const outer = new ZipReader(reader);
     try {
-        let nestedEntry:
-            | Awaited<ReturnType<typeof outer.getEntries>>[number]
-            | undefined;
+        let nestedEntry: FileEntry | undefined;
         for await (const entry of outer.getEntriesGenerator()) {
-            if (entry.filename === 'artifacts.zip') {
+            if (!entry.directory && entry.filename === 'artifacts.zip') {
                 nestedEntry = entry;
                 break;
             }
@@ -208,7 +168,6 @@ async function extractWindowsBuildReader<T>(
         if (!nestedEntry || nestedEntry.compressionMethod !== 0) {
             throw new Error('Windows artifact has no stored artifacts.zip');
         }
-
         const dataOffset = await storedEntryDataOffset(
             reader,
             nestedEntry.offset,
@@ -255,31 +214,16 @@ async function extractWindowsBuildReader<T>(
     }
 }
 
-async function extractMacBuild(
+async function extractBuild(
     artifactPath: string,
     destDir: string,
+    kind: BuildArtifactKind,
 ): Promise<number> {
-    const file = await Deno.open(artifactPath, { read: true });
-    try {
-        return await extractMacBuildReader(new DenoFileReader(file), destDir);
-    } finally {
-        file.close();
-    }
-}
-
-async function extractWindowsBuild(
-    artifactPath: string,
-    destDir: string,
-): Promise<number> {
-    const file = await Deno.open(artifactPath, { read: true });
-    try {
-        return await extractWindowsBuildReader(
-            new DenoFileReader(file),
-            destDir,
-        );
-    } finally {
-        file.close();
-    }
+    using file = await Deno.open(artifactPath, { read: true });
+    const reader = new DenoFileReader(file);
+    return await (kind === 'mac-build'
+        ? extractMacBuildReader(reader, destDir)
+        : extractWindowsBuildReader(reader, destDir));
 }
 
 async function downloadArtifact(
@@ -294,30 +238,42 @@ async function downloadArtifact(
         create: true,
         truncate: true,
         write: true,
+        mode: 0o600,
     });
     let downloaded = 0;
     let lastLogged = 0;
     const started = Date.now();
+    const logRetry = (attempt: number, err: unknown) =>
+        logEvent('artifact_build_download_retry', {
+            bytes: downloaded,
+            total_bytes: artifactSize,
+            attempt: attempt + 1,
+            error: err instanceof Error ? err.message : String(err),
+        });
 
     try {
         for (
             let attempt = 1;
-            attempt <= 5 && downloaded < artifactSize;
+            attempt <= MAX_DOWNLOAD_ATTEMPTS && downloaded < artifactSize;
             attempt++
         ) {
-            const headers: Record<string, string> = {
-                Accept: 'application/vnd.github+json',
-                Authorization: `Bearer ${token}`,
-                'X-GitHub-Api-Version': '2022-11-28',
-                'User-Agent': 'minidumpster-artifact-crawler',
-            };
+            const headers = githubApiHeaders(token);
             if (downloaded > 0) headers.Range = `bytes=${downloaded}-`;
 
-            const response = await fetchFn(artifactUrl, {
-                headers,
-                redirect: 'follow',
-                signal,
-            });
+            let response: Response;
+            try {
+                response = await fetchFn(artifactUrl, {
+                    headers,
+                    redirect: 'follow',
+                    signal,
+                });
+            } catch (err) {
+                if (attempt >= MAX_DOWNLOAD_ATTEMPTS || signal?.aborted) {
+                    throw err;
+                }
+                logRetry(attempt, err);
+                continue;
+            }
             if (!response.ok || !response.body) {
                 throw await githubHttpError(
                     'GitHub artifact download failed',
@@ -326,22 +282,35 @@ async function downloadArtifact(
             }
             if (downloaded > 0 && response.status !== 206) {
                 await response.body.cancel();
-                throw new Error(
+                throw new ArtifactSizeMismatchError(
                     'artifact server did not honor download resume range',
+                );
+            }
+            const declared = Number(response.headers.get('content-length'));
+            if (
+                Number.isFinite(declared)
+                && declared > artifactSize - downloaded
+            ) {
+                await response.body.cancel();
+                throw new Error(
+                    'artifact response exceeds its declared metadata size',
                 );
             }
 
             try {
                 for await (const chunk of response.body) {
-                    let offset = 0;
-                    while (offset < chunk.length) {
-                        offset += await file.write(chunk.subarray(offset));
-                    }
-                    downloaded += chunk.length;
-                    if (downloaded > artifactSize) {
-                        throw new Error(
+                    if (chunk.length > artifactSize - downloaded) {
+                        throw new ArtifactSizeMismatchError(
                             `artifact download exceeded expected size ${artifactSize}`,
                         );
+                    }
+                    let offset = 0;
+                    while (offset < chunk.length) {
+                        const written = await file.write(
+                            chunk.subarray(offset),
+                        );
+                        offset += written;
+                        downloaded += written;
                     }
                     if (downloaded - lastLogged >= 512 * 1024 * 1024) {
                         lastLogged = downloaded;
@@ -356,26 +325,23 @@ async function downloadArtifact(
                     }
                 }
             } catch (err) {
-                if (attempt >= 5 || signal?.aborted) {
+                if (
+                    err instanceof ArtifactSizeMismatchError
+                    || attempt >= MAX_DOWNLOAD_ATTEMPTS
+                    || signal?.aborted
+                ) {
                     throw err;
                 }
 
-                logEvent('artifact_build_download_retry', {
-                    bytes: downloaded,
-                    total_bytes: artifactSize,
-                    attempt: attempt + 1,
-                    error: err instanceof Error ? err.message : String(err),
-                });
+                logRetry(attempt, err);
                 continue;
             }
 
-            if (downloaded < artifactSize && attempt < 5) {
-                logEvent('artifact_build_download_retry', {
-                    bytes: downloaded,
-                    total_bytes: artifactSize,
-                    attempt: attempt + 1,
-                    error: 'download ended before the expected artifact size',
-                });
+            if (downloaded < artifactSize && attempt < MAX_DOWNLOAD_ATTEMPTS) {
+                logRetry(
+                    attempt,
+                    'download ended before the expected artifact size',
+                );
             }
         }
     } finally {
@@ -427,9 +393,7 @@ export async function ingestBuildArtifact(
         );
         let files: number;
         try {
-            files = kind === 'mac-build'
-                ? await extractMacBuild(artifactPath, extractedDir)
-                : await extractWindowsBuild(artifactPath, extractedDir);
+            files = await extractBuild(artifactPath, extractedDir, kind);
         } catch (err) {
             throw new Error(
                 `build artifact extraction failed: ${
@@ -455,6 +419,5 @@ export async function ingestBuildArtifact(
 
 export const _test = {
     downloadArtifact,
-    extractMacBuild,
-    extractWindowsBuild,
+    extractBuild,
 };

--- a/svc/minidumpster/src/build-artifacts.ts
+++ b/svc/minidumpster/src/build-artifacts.ts
@@ -286,6 +286,10 @@ async function downloadArtifact(
                     'artifact server did not honor download resume range',
                 );
             }
+
+            // artifactSize comes from GitHub's artifact metadata, not this
+            // HTTP response. fetch does not know that expected size, so check
+            // both the advertised length and the streamed bytes against it.
             const declared = Number(response.headers.get('content-length'));
             if (
                 Number.isFinite(declared)

--- a/svc/minidumpster/src/db.ts
+++ b/svc/minidumpster/src/db.ts
@@ -1,6 +1,6 @@
 import { DatabaseSync } from 'node:sqlite';
 
-export type ReportStatus = 'pending' | 'processing' | 'processed' | 'failed';
+export type ReportStatus = 'pending' | 'processing' | 'processed';
 export type ReportKind = 'minidump' | 'apple';
 
 export interface ReportRow {
@@ -19,7 +19,6 @@ export interface ReportRow {
     next_attempt_at: number;
     received_at: number;
     processed_at: number | null;
-    dump_deleted: number;
     kind: ReportKind;
     symbolicated: number;
 }
@@ -92,13 +91,15 @@ CREATE TABLE IF NOT EXISTS reports (
   next_attempt_at INTEGER NOT NULL DEFAULT 0,
   received_at INTEGER NOT NULL,
   processed_at INTEGER,
-  dump_deleted INTEGER NOT NULL DEFAULT 0,
   kind TEXT NOT NULL DEFAULT 'minidump',
   symbolicated INTEGER NOT NULL DEFAULT 1
 );
-CREATE INDEX IF NOT EXISTS idx_reports_status ON reports(status);
+CREATE INDEX IF NOT EXISTS idx_reports_queue
+  ON reports(status, next_attempt_at, received_at);
 CREATE INDEX IF NOT EXISTS idx_reports_group ON reports(group_id, received_at);
 CREATE INDEX IF NOT EXISTS idx_reports_prod_ver ON reports(product, version);
+-- Migration: replaced by idx_reports_queue in databases created before it.
+DROP INDEX IF EXISTS idx_reports_status;
 CREATE TABLE IF NOT EXISTS groups (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   signature TEXT UNIQUE NOT NULL,
@@ -142,6 +143,18 @@ export class Db {
         return this.db.prepare(sql).all(...params) as T[];
     }
 
+    private inWriteTransaction<T>(fn: () => T): T {
+        this.db.exec('BEGIN IMMEDIATE');
+        try {
+            const result = fn();
+            this.db.exec('COMMIT');
+            return result;
+        } catch (err) {
+            this.db.exec('ROLLBACK');
+            throw err;
+        }
+    }
+
     close(): void {
         this.db.close();
     }
@@ -182,8 +195,8 @@ export class Db {
 
         return this.many<ReportRow>(
             `SELECT * FROM reports
-       WHERE lower(id) = ? OR lower(guid) = ?
-          OR lower(id) LIKE ? OR lower(guid) LIKE ?
+       WHERE id = ? OR lower(guid) = ?
+          OR id LIKE ? OR lower(guid) LIKE ?
        ORDER BY received_at DESC LIMIT ?`,
             q,
             q,
@@ -193,28 +206,17 @@ export class Db {
         );
     }
 
-    claimPending(limit: number, now: number): ReportRow[] {
-        this.db.exec('BEGIN IMMEDIATE');
-        try {
-            const rows = this.many<ReportRow>(
-                `SELECT * FROM reports WHERE status = 'pending' AND next_attempt_at <= ?
-         ORDER BY received_at LIMIT ?`,
-                now,
-                limit,
-            );
-            const upd = this.db.prepare(
-                `UPDATE reports SET status = 'processing' WHERE id = ?`,
-            );
-            for (const row of rows) {
-                upd.run(row.id);
-            }
-
-            this.db.exec('COMMIT');
-            return rows;
-        } catch (e) {
-            this.db.exec('ROLLBACK');
-            throw e;
-        }
+    claimNext(now: number): ReportRow | null {
+        return this.one<ReportRow>(
+            `UPDATE reports SET status = 'processing'
+       WHERE id IN (
+         SELECT id FROM reports
+         WHERE status = 'pending' AND next_attempt_at <= ?
+         ORDER BY received_at LIMIT 1
+       )
+       RETURNING *`,
+            now,
+        );
     }
 
     resetProcessing(): number {
@@ -231,11 +233,19 @@ export class Db {
         platform: string | null,
         processedAt: number,
         symbolicated: boolean,
+        attempts: number,
     ): void {
         this.db.prepare(
-            `UPDATE reports SET status = 'processed', group_id = ?, platform = ?, processed_at = ?, symbolicated = ?, error = NULL
+            `UPDATE reports SET status = 'processed', group_id = ?, platform = ?, processed_at = ?, symbolicated = ?, attempts = ?, next_attempt_at = 0, error = NULL
        WHERE id = ?`,
-        ).run(groupId, platform, processedAt, symbolicated ? 1 : 0, id);
+        ).run(
+            groupId,
+            platform,
+            processedAt,
+            symbolicated ? 1 : 0,
+            attempts,
+            id,
+        );
     }
 
     requeueUnsymbolicated(
@@ -261,12 +271,6 @@ export class Db {
         this.db.prepare(
             `UPDATE reports SET status = 'pending', error = ?, attempts = ?, next_attempt_at = ? WHERE id = ?`,
         ).run(error, attempts, nextAttemptAt, id);
-    }
-
-    markFailed(id: string, error: string, attempts: number): void {
-        this.db.prepare(
-            `UPDATE reports SET status = 'failed', error = ?, attempts = ? WHERE id = ?`,
-        ).run(error, attempts, id);
     }
 
     registerArtifact(
@@ -470,16 +474,29 @@ export class Db {
         };
     }
 
-    dumpsOlderThan(cutoffMs: number): string[] {
-        return this.many<{ id: string }>(
-            `SELECT id FROM reports WHERE received_at < ? AND dump_deleted = 0`,
-            cutoffMs,
-        ).map((r) => r.id);
+    deleteExpiredReports(cutoffMs: number): string[] {
+        return this.inWriteTransaction(() => {
+            const expiredReports = this.many<{
+                id: string;
+                group_id: number | null;
+            }>(
+                `DELETE FROM reports
+         WHERE received_at < ? AND status <> 'processing'
+         RETURNING id, group_id`,
+                cutoffMs,
+            );
+            this.recountGroups(expiredReports.map((report) => report.group_id));
+            return expiredReports.map((report) => report.id);
+        });
     }
 
-    markDumpDeleted(id: string): void {
-        this.db.prepare(`UPDATE reports SET dump_deleted = 1 WHERE id = ?`).run(
-            id,
-        );
+    deleteReport(id: string): void {
+        this.inWriteTransaction(() => {
+            const groupId = this.one<{ group_id: number | null }>(
+                `DELETE FROM reports WHERE id = ? RETURNING group_id`,
+                id,
+            )?.group_id ?? null;
+            this.recountGroups([groupId]);
+        });
     }
 }

--- a/svc/minidumpster/src/db.ts
+++ b/svc/minidumpster/src/db.ts
@@ -1,6 +1,6 @@
 import { DatabaseSync } from 'node:sqlite';
 
-export type ReportStatus = 'pending' | 'processing' | 'processed';
+export type ReportStatus = 'pending' | 'processing' | 'processed' | 'failed';
 export type ReportKind = 'minidump' | 'apple';
 
 export interface ReportRow {
@@ -98,8 +98,6 @@ CREATE INDEX IF NOT EXISTS idx_reports_queue
   ON reports(status, next_attempt_at, received_at);
 CREATE INDEX IF NOT EXISTS idx_reports_group ON reports(group_id, received_at);
 CREATE INDEX IF NOT EXISTS idx_reports_prod_ver ON reports(product, version);
--- Migration: replaced by idx_reports_queue in databases created before it.
-DROP INDEX IF EXISTS idx_reports_status;
 CREATE TABLE IF NOT EXISTS groups (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   signature TEXT UNIQUE NOT NULL,
@@ -122,6 +120,24 @@ CREATE TABLE IF NOT EXISTS artifact_ingests (
 );
 `;
 
+function migrateSchema(db: DatabaseSync): void {
+    // Replaced by idx_reports_queue in databases created before it.
+    db.exec('DROP INDEX IF EXISTS idx_reports_status');
+
+    const legacyColumn = db.prepare(`
+        SELECT 1
+        FROM pragma_table_info('reports')
+        WHERE name = 'dump_deleted'
+        LIMIT 1
+    `).get();
+
+    if (!legacyColumn) {
+        return;
+    }
+
+    db.exec('ALTER TABLE reports DROP COLUMN dump_deleted');
+}
+
 export class Db {
     private db: DatabaseSync;
 
@@ -130,6 +146,7 @@ export class Db {
         this.db.exec('PRAGMA journal_mode = WAL;');
         this.db.exec('PRAGMA busy_timeout = 5000;');
         this.db.exec(SCHEMA);
+        migrateSchema(this.db);
     }
 
     private one<T extends object>(

--- a/svc/minidumpster/src/github.ts
+++ b/svc/minidumpster/src/github.ts
@@ -1,3 +1,12 @@
+export function githubApiHeaders(token: string): Record<string, string> {
+    return {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'minidumpster',
+    };
+}
+
 export async function checkOrgMembership(
     fetchFn: typeof fetch,
     token: string,
@@ -7,13 +16,7 @@ export async function checkOrgMembership(
         `https://api.github.com/user/memberships/orgs/${
             encodeURIComponent(org)
         }`,
-        {
-            headers: {
-                Accept: 'application/vnd.github+json',
-                'User-Agent': 'minidumpster-crash-service',
-                Authorization: `Bearer ${token}`,
-            },
-        },
+        { headers: githubApiHeaders(token) },
     );
 
     if (!res.ok) {

--- a/svc/minidumpster/src/main.ts
+++ b/svc/minidumpster/src/main.ts
@@ -20,8 +20,8 @@ if (import.meta.main) {
     const db = new Db(Paths.dbPath(config.dataDir));
     const app = App.buildApp({ config, db });
 
-    const worker = Worker.startWorker({ db, config });
     const stopRetention = Retention.startRetentionJob(db, config);
+    const worker = Worker.startWorker({ db, config });
 
     const server = Deno.serve({ port: config.port }, app.fetch);
     const artifactCrawler = ArtifactCrawler.startArtifactCrawler({

--- a/svc/minidumpster/src/main.ts
+++ b/svc/minidumpster/src/main.ts
@@ -33,7 +33,12 @@ if (import.meta.main) {
         data_dir: config.dataDir,
     });
 
+    let shuttingDown = false;
     const shutdown = async () => {
+        if (shuttingDown) {
+            return;
+        }
+        shuttingDown = true;
         Log.logEvent('server_stopping');
         stopRetention();
         await artifactCrawler.stop();

--- a/svc/minidumpster/src/multipart.ts
+++ b/svc/minidumpster/src/multipart.ts
@@ -16,18 +16,32 @@ export interface StreamedMultipart {
     files: StreamedFile[];
 }
 
+const MAX_BODY_BYTES = 16 * 1024 * 1024;
+
+async function* cappedBody(
+    body: ReadableStream<Uint8Array>,
+): AsyncGenerator<Uint8Array> {
+    let received = 0;
+    for await (const chunk of body) {
+        received += chunk.byteLength;
+        if (received > MAX_BODY_BYTES) {
+            throw new Error(`multipart: body exceeds ${MAX_BODY_BYTES} bytes`);
+        }
+        yield chunk;
+    }
+}
+
 export function streamMultipartToDisk(
     body: ReadableStream<Uint8Array>,
     contentType: string,
     fileDest: (field: string, filename: string) => string,
-    opts: { maxFieldBytes?: number } = {},
 ): Promise<StreamedMultipart> {
     return new Promise((resolve, reject) => {
         let bb: busboy.Busboy;
         try {
             bb = busboy({
                 headers: { 'content-type': contentType },
-                limits: { fieldSize: opts.maxFieldBytes ?? 64 * 1024 },
+                limits: { fieldSize: 64 * 1024 },
             });
         } catch (err) {
             reject(err);
@@ -82,7 +96,6 @@ export function streamMultipartToDisk(
         });
 
         bb.on('error', fail);
-        bb.on('partsLimit', () => fail(new Error('multipart: too many parts')));
         bb.on('close', () => {
             Promise.all(fileWrites)
                 .then(() => {
@@ -93,6 +106,6 @@ export function streamMultipartToDisk(
                 .catch(fail);
         });
 
-        Readable.from(body).on('error', fail).pipe(bb);
+        Readable.from(cappedBody(body)).on('error', fail).pipe(bb);
     });
 }

--- a/svc/minidumpster/src/multipart.ts
+++ b/svc/minidumpster/src/multipart.ts
@@ -16,21 +16,6 @@ export interface StreamedMultipart {
     files: StreamedFile[];
 }
 
-const MAX_BODY_BYTES = 16 * 1024 * 1024;
-
-async function* cappedBody(
-    body: ReadableStream<Uint8Array>,
-): AsyncGenerator<Uint8Array> {
-    let received = 0;
-    for await (const chunk of body) {
-        received += chunk.byteLength;
-        if (received > MAX_BODY_BYTES) {
-            throw new Error(`multipart: body exceeds ${MAX_BODY_BYTES} bytes`);
-        }
-        yield chunk;
-    }
-}
-
 export function streamMultipartToDisk(
     body: ReadableStream<Uint8Array>,
     contentType: string,
@@ -106,6 +91,6 @@ export function streamMultipartToDisk(
                 .catch(fail);
         });
 
-        Readable.from(cappedBody(body)).on('error', fail).pipe(bb);
+        Readable.from(body).on('error', fail).pipe(bb);
     });
 }

--- a/svc/minidumpster/src/reports.ts
+++ b/svc/minidumpster/src/reports.ts
@@ -3,6 +3,15 @@ import type { Db, NewReport } from './db.ts';
 import { logError } from './log.ts';
 import { dumpPath, processedPath } from './paths.ts';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function reportExpiresAt(
+    receivedAt: number,
+    retentionDays: number,
+): number {
+    return receivedAt + retentionDays * DAY_MS;
+}
+
 function removeIfExists(path: string): void {
     try {
         Deno.removeSync(path);

--- a/svc/minidumpster/src/reports.ts
+++ b/svc/minidumpster/src/reports.ts
@@ -1,0 +1,60 @@
+import type { Config } from './config.ts';
+import type { Db, NewReport } from './db.ts';
+import { logError } from './log.ts';
+import { dumpPath, processedPath } from './paths.ts';
+
+function removeIfExists(path: string): void {
+    try {
+        Deno.removeSync(path);
+    } catch (err) {
+        if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
+}
+
+/**
+ * Insert the row for a dump already stored at dumpPath(report.id), removing
+ * the file again if the insert fails so no unreachable dump is left behind.
+ */
+export function insertReportForStoredDump(
+    db: Db,
+    config: Config,
+    report: NewReport,
+): void {
+    try {
+        db.insertReport(report);
+    } catch (err) {
+        try {
+            removeIfExists(dumpPath(config.dataDir, report.id));
+        } catch (deleteErr) {
+            logError('report_insert_cleanup_error', deleteErr, {
+                report_id: report.id,
+            });
+        }
+        throw err;
+    }
+}
+
+export function deleteReportAndPayload(
+    db: Db,
+    config: Config,
+    reportId: string,
+): void {
+    // Delete the database row first so downloads and searches are denied even
+    // if file removal fails.
+    db.deleteReport(reportId);
+    for (
+        const [kind, path] of [
+            ['raw', dumpPath(config.dataDir, reportId)],
+            ['processed', processedPath(config.dataDir, reportId)],
+        ] as const
+    ) {
+        try {
+            removeIfExists(path);
+        } catch (err) {
+            logError('report_payload_delete_error', err, {
+                report_id: reportId,
+                kind,
+            });
+        }
+    }
+}

--- a/svc/minidumpster/src/retention.ts
+++ b/svc/minidumpster/src/retention.ts
@@ -3,34 +3,47 @@ import { join } from '@std/path';
 import type { Db } from './db.ts';
 import type { Config } from './config.ts';
 import { logError, logEvent } from './log.ts';
-import { dumpPath, symbolsDir } from './paths.ts';
+import { dumpPath, processedPath, symbolsDir } from './paths.ts';
 
-export async function runRetention(
+function removeIfExists(path: string): void {
+    try {
+        Deno.removeSync(path);
+    } catch (err) {
+        if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
+}
+
+const REPORT_STORES = [
+    ['raw', dumpPath],
+    ['processed', processedPath],
+] as const;
+
+export function runRetention(
     db: Db,
     config: Config,
     now: number = Date.now(),
-): Promise<number> {
+): number {
     const cutoff = now - config.retentionDays * 24 * 60 * 60 * 1000;
 
-    let deleted = 0;
-    for (const id of db.dumpsOlderThan(cutoff)) {
-        try {
-            await Deno.remove(dumpPath(config.dataDir, id));
-            deleted++;
-        } catch (err) {
-            if (!(err instanceof Deno.errors.NotFound)) {
-                logError('retention_delete_error', err, { report_id: id });
-                continue;
+    const expired = db.deleteExpiredReports(cutoff);
+    for (const id of expired) {
+        for (const [kind, path] of REPORT_STORES) {
+            try {
+                removeIfExists(path(config.dataDir, id));
+            } catch (err) {
+                logError('retention_file_delete_error', err, {
+                    report_id: id,
+                    kind,
+                });
             }
         }
-        db.markDumpDeleted(id);
     }
 
-    if (deleted > 0) {
-        logEvent('retention_run', { deleted, cutoff });
+    if (expired.length > 0) {
+        logEvent('retention_run', { deleted: expired.length, cutoff });
     }
 
-    return deleted;
+    return expired.length;
 }
 
 export async function runSymbolRetention(
@@ -125,9 +138,11 @@ export async function runSymbolRetention(
 
 export function startRetentionJob(db: Db, config: Config): () => void {
     const run = () => {
-        runRetention(db, config).catch((err) =>
-            logError('retention_error', err)
-        );
+        try {
+            runRetention(db, config);
+        } catch (err) {
+            logError('retention_error', err);
+        }
         runSymbolRetention(config).catch((err) =>
             logError('symbols_retention_error', err)
         );

--- a/svc/minidumpster/src/routes/auth.ts
+++ b/svc/minidumpster/src/routes/auth.ts
@@ -94,6 +94,7 @@ export function requireSession(config: Config): MiddlewareHandler<Env> {
         const raw = await getSignedCookie(c, config.sessionSecret, 'session');
         const session = decodeSession(raw);
         if (!session) {
+            c.header('cache-control', 'no-store');
             return c.redirect('/auth/login');
         }
 

--- a/svc/minidumpster/src/routes/ingest.ts
+++ b/svc/minidumpster/src/routes/ingest.ts
@@ -77,10 +77,6 @@ export function ingestRoutes(deps: AppDeps): Hono<Env> {
 
                 logEvent('report_received', {
                     report_id: id,
-                    product: annotations['prod'] ?? null,
-                    version: annotations['ver'] ?? null,
-                    ptype: annotations['ptype'] ?? null,
-                    channel: annotations['channel'] ?? null,
                     dump_bytes: dump.byteLength,
                 });
 

--- a/svc/minidumpster/src/routes/ingest.ts
+++ b/svc/minidumpster/src/routes/ingest.ts
@@ -6,6 +6,7 @@ import { logError, logEvent } from '../log.ts';
 import type { AppDeps, Env } from '../app.ts';
 import { ingestSymbolUpload } from '../symbols.ts';
 import { dumpPath, writeFileWithDirs } from '../paths.ts';
+import { insertReportForStoredDump } from '../reports.ts';
 import { HttpError, parseCrashRequest } from '../crash.ts';
 import { symbolicatorReachable } from '../symbolicator.ts';
 
@@ -61,11 +62,9 @@ export function ingestRoutes(deps: AppDeps): Hono<Env> {
                     c.req.raw,
                     config.maxDumpSizeBytes,
                 );
-
                 const id = crypto.randomUUID();
                 await writeFileWithDirs(dumpPath(config.dataDir, id), dump);
-
-                db.insertReport({
+                insertReportForStoredDump(db, config, {
                     id,
                     product: annotations['prod'] ?? null,
                     version: annotations['ver'] ?? null,

--- a/svc/minidumpster/src/routes/web.ts
+++ b/svc/minidumpster/src/routes/web.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type MiddlewareHandler } from 'hono';
 import { serveStatic } from 'hono/deno';
 
 import * as ui from '../ui.ts';
@@ -7,6 +7,7 @@ import { requireSession } from './auth.ts';
 import type { GroupFilter } from '../db.ts';
 import type { AppDeps, Env } from '../app.ts';
 import type { SymbolicatorResponse } from '../signature.ts';
+import { insertReportForStoredDump } from '../reports.ts';
 import {
     dumpPath,
     processedPath,
@@ -18,6 +19,14 @@ import {
     parseAppleCrashMeta,
 } from '../applecrash.ts';
 
+const disablePrivateResponseCaching: MiddlewareHandler<Env> = async (
+    c,
+    next,
+) => {
+    await next();
+    c.header('cache-control', 'private, no-store');
+};
+
 async function readProcessed(
     dataDir: string,
     reportId: string,
@@ -27,7 +36,7 @@ async function readProcessed(
             await Deno.readTextFile(processedPath(dataDir, reportId)),
         ) as SymbolicatorResponse;
     } catch (err) {
-        logEvent('failed_parsing_processed', { dataDir, reportId, err });
+        logError('failed_parsing_processed', err, { dataDir, reportId });
         return null;
     }
 }
@@ -68,6 +77,7 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
     app.get('/app.js', serveStatic({ path: './src/static/app.js' }));
 
     app.use('*', requireSession(config));
+    app.use('*', disablePrivateResponseCaching);
 
     app.get('/', (c) => {
         const filter: GroupFilter = {
@@ -123,7 +133,6 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
 
     app.post('/upload', async (c) => {
         const login = c.get('session').login;
-
         let form: FormData;
         try {
             form = await c.req.raw.formData();
@@ -146,6 +155,7 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
             text = pasted;
         }
         text = text.trim();
+        const encoded = new TextEncoder().encode(text);
 
         if (text === '') {
             return c.html(
@@ -153,7 +163,7 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
                 400,
             );
         }
-        if (text.length > config.maxDumpSizeBytes) {
+        if (encoded.byteLength > config.maxDumpSizeBytes) {
             return c.html(ui.uploadPage(login, 'Report too large.'), 413);
         }
         if (!looksLikeAppleCrashReport(text)) {
@@ -168,21 +178,12 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
         }
 
         const meta = parseAppleCrashMeta(text);
-        if (meta.incidentId) {
-            const existing = db.findReportByGuid(meta.incidentId);
-            if (existing) {
-                if (existing.status === 'failed') {
-                    db.markRetry(existing.id, 'requeued by re-upload', 0, 0);
-                }
-                return c.redirect(`/reports/${existing.id}`);
-            }
+        const existing = meta.incidentId
+            ? db.findReportByGuid(meta.incidentId)
+            : null;
+        if (existing) {
+            return c.redirect(`/reports/${existing.id}`);
         }
-
-        const id = crypto.randomUUID();
-        await writeFileWithDirs(
-            dumpPath(config.dataDir, id),
-            new TextEncoder().encode(text),
-        );
 
         const annotations: Record<string, string> = {
             source: 'manual-apple-crash-report',
@@ -192,7 +193,9 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
         if (meta.osVersion) annotations['os_version'] = meta.osVersion;
         if (meta.hardwareModel) annotations['hw_model'] = meta.hardwareModel;
 
-        db.insertReport({
+        const id = crypto.randomUUID();
+        await writeFileWithDirs(dumpPath(config.dataDir, id), encoded);
+        insertReportForStoredDump(db, config, {
             id,
             kind: 'apple',
             product: meta.process,
@@ -207,10 +210,8 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
         logEvent('report_received', {
             report_id: id,
             kind: 'apple',
-            product: meta.process,
-            version: meta.version,
             uploaded_by: login,
-            bytes: text.length,
+            bytes: encoded.byteLength,
         });
 
         return c.redirect(`/reports/${id}`);
@@ -261,13 +262,19 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
         }
 
         return c.html(
-            ui.reportPage(report, group, stack, c.get('session').login),
+            ui.reportPage(
+                report,
+                group,
+                stack,
+                report.received_at + config.retentionDays * 86_400_000,
+                c.get('session').login,
+            ),
         );
     });
 
     app.get('/reports/:id/dump', async (c) => {
         const report = db.getReport(c.req.param('id'));
-        if (!report || report.dump_deleted) {
+        if (!report) {
             return c.text('not found\n', 404);
         }
 
@@ -292,7 +299,7 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
 
     app.get('/reports/:id/json', async (c) => {
         const report = db.getReport(c.req.param('id'));
-        if (!report) {
+        if (!report || report.status !== 'processed') {
             return c.text('not found\n', 404);
         }
 

--- a/svc/minidumpster/src/routes/web.ts
+++ b/svc/minidumpster/src/routes/web.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { serveStatic } from 'hono/deno';
 
 import * as ui from '../ui.ts';
 import { logError, logEvent } from '../log.ts';
@@ -16,10 +17,6 @@ import {
     looksLikeAppleCrashReport,
     parseAppleCrashMeta,
 } from '../applecrash.ts';
-
-const styleCss = Deno.readTextFileSync(
-    new URL('../static/style.css', import.meta.url),
-);
 
 async function readProcessed(
     dataDir: string,
@@ -64,13 +61,11 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
     const { config, db } = deps;
     const app = new Hono<Env>();
 
-    // Registered before the session gate: the login/denied pages served by the
-    // auth routes use the same layout, so the stylesheet must be public.
-    app.get('/style.css', (c) =>
-        c.body(styleCss, 200, {
-            'content-type': 'text/css; charset=utf-8',
-            'cache-control': 'public, max-age=300',
-        }));
+    // Registered before the session gate: login/denied pages use the shared
+    // layout, so its static assets must be public.
+    app.get('/style.css', serveStatic({ path: './src/static/style.css' }));
+    app.get('/favicon.svg', serveStatic({ path: './src/static/favicon.svg' }));
+    app.get('/app.js', serveStatic({ path: './src/static/app.js' }));
 
     app.use('*', requireSession(config));
 

--- a/svc/minidumpster/src/routes/web.ts
+++ b/svc/minidumpster/src/routes/web.ts
@@ -7,7 +7,7 @@ import { requireSession } from './auth.ts';
 import type { GroupFilter } from '../db.ts';
 import type { AppDeps, Env } from '../app.ts';
 import type { SymbolicatorResponse } from '../signature.ts';
-import { insertReportForStoredDump } from '../reports.ts';
+import { insertReportForStoredDump, reportExpiresAt } from '../reports.ts';
 import {
     dumpPath,
     processedPath,
@@ -72,9 +72,7 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
 
     // Registered before the session gate: login/denied pages use the shared
     // layout, so its static assets must be public.
-    app.get('/style.css', serveStatic({ path: './src/static/style.css' }));
-    app.get('/favicon.svg', serveStatic({ path: './src/static/favicon.svg' }));
-    app.get('/app.js', serveStatic({ path: './src/static/app.js' }));
+    app.use('/static/*', serveStatic({ root: './src' }));
 
     app.use('*', requireSession(config));
     app.use('*', disablePrivateResponseCaching);
@@ -155,7 +153,6 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
             text = pasted;
         }
         text = text.trim();
-        const encoded = new TextEncoder().encode(text);
 
         if (text === '') {
             return c.html(
@@ -163,6 +160,7 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
                 400,
             );
         }
+        const encoded = new TextEncoder().encode(text);
         if (encoded.byteLength > config.maxDumpSizeBytes) {
             return c.html(ui.uploadPage(login, 'Report too large.'), 413);
         }
@@ -182,6 +180,9 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
             ? db.findReportByGuid(meta.incidentId)
             : null;
         if (existing) {
+            if (existing.status === 'failed') {
+                db.markRetry(existing.id, 'requeued by re-upload', 0, 0);
+            }
             return c.redirect(`/reports/${existing.id}`);
         }
 
@@ -266,7 +267,10 @@ export function webRoutes(deps: AppDeps): Hono<Env> {
                 report,
                 group,
                 stack,
-                report.received_at + config.retentionDays * 86_400_000,
+                reportExpiresAt(
+                    report.received_at,
+                    config.retentionDays,
+                ),
                 c.get('session').login,
             ),
         );

--- a/svc/minidumpster/src/signature.ts
+++ b/svc/minidumpster/src/signature.ts
@@ -91,7 +91,7 @@ function moduleFor(
     }) ?? null;
 }
 
-export function frameLabel(f: SymFrame, modules?: SymModule[]): string {
+function frameLabel(f: SymFrame, modules?: SymModule[]): string {
     const fn = f.function ?? f.symbol;
     if (fn && fn.trim() !== '') {
         return fn.trim().replace(/\s+/g, ' ');
@@ -177,14 +177,12 @@ function skipSentinelFrames(frames: SymFrame[]): SymFrame[] {
 }
 
 async function sha256Hex(text: string): Promise<string> {
-    const digest = await crypto.subtle.digest(
-        'SHA-256',
-        new TextEncoder().encode(text),
-    );
-
-    return Array.from(new Uint8Array(digest)).map((b) =>
-        b.toString(16).padStart(2, '0')
-    ).join('');
+    return new Uint8Array(
+        await crypto.subtle.digest(
+            'SHA-256',
+            new TextEncoder().encode(text),
+        ),
+    ).toHex();
 }
 
 export async function computeSignature(
@@ -218,15 +216,7 @@ export async function fallbackSignature(
     resp: SymbolicatorResponse,
 ): Promise<SignatureResult> {
     const reason = resp.crash_reason?.trim() || 'no stacktrace';
-
-    const digest = await crypto.subtle.digest(
-        'SHA-256',
-        new TextEncoder().encode(`reason:${reason}`),
-    );
-    const signature = Array.from(new Uint8Array(digest)).map((b) =>
-        b.toString(16).padStart(2, '0')
-    )
-        .join('');
+    const signature = await sha256Hex(`reason:${reason}`);
 
     return { signature, title: reason, symbolicated: false };
 }

--- a/svc/minidumpster/src/static/app.js
+++ b/svc/minidumpster/src/static/app.js
@@ -1,0 +1,9 @@
+document.addEventListener('click', (event) => {
+    const target = event.target.closest('.expandable');
+    if (!target) {
+        return;
+    }
+    const full = target.dataset.full;
+    target.dataset.full = target.textContent;
+    target.textContent = full;
+});

--- a/svc/minidumpster/src/static/favicon.svg
+++ b/svc/minidumpster/src/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" fill="none">
+    <rect width="256" height="256" fill="#3450d1" rx="60" />
+    <path stroke="#fff" stroke-linecap="square" stroke-linejoin="round"
+        stroke-width="31.808"
+        d="M160.926 140 243 70 160.924 0m58.842 70.057H-158M93.074 256 11 185.999 93.076 116m-58.842 70.057H412" />
+</svg>

--- a/svc/minidumpster/src/static/style.css
+++ b/svc/minidumpster/src/static/style.css
@@ -29,19 +29,18 @@ code,
 
 header {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 1rem;
     padding: 1rem 0;
     border-bottom: 1px solid color-mix(in srgb, var(--line) 27%, transparent);
     margin-bottom: 1rem;
 
-    h1 {
-        font-size: 1.2rem;
-        margin: 0;
+    a.brand {
+        display: flex;
 
-        a {
-            text-decoration: none;
-            color: inherit;
+        img {
+            width: 24px;
+            height: 24px;
         }
     }
 
@@ -188,4 +187,25 @@ form.filters {
 
 .overflow {
     overflow-x: auto;
+}
+
+@media (max-width: 640px) {
+    header {
+        flex-wrap: wrap;
+
+        .user {
+            margin-left: 0;
+        }
+
+        form.search {
+            order: 1;
+            flex: 1 0 100%;
+            margin-left: 0;
+
+            input {
+                box-sizing: border-box;
+                width: 100%;
+            }
+        }
+    }
 }

--- a/svc/minidumpster/src/symbolicator.ts
+++ b/svc/minidumpster/src/symbolicator.ts
@@ -107,12 +107,6 @@ async function submitAndPoll(
         body = await poll.json() as SymbolicatorResponse;
     }
 
-    if (body.status !== 'completed') {
-        throw new Error(
-            `symbolication ${body.status}: ${body.message ?? 'no details'}`,
-        );
-    }
-
     return body;
 }
 

--- a/svc/minidumpster/src/symbolicator.ts
+++ b/svc/minidumpster/src/symbolicator.ts
@@ -1,16 +1,20 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { logError } from './log.ts';
 import type { SymbolicatorResponse } from './signature.ts';
+
+const REQUEST_TIMEOUT_SECONDS = 5 * 60;
 
 export interface SymbolicateOptions {
     fetchFn?: typeof fetch;
     /** Delay between polls when Symbolicator doesn't suggest one. */
     pollIntervalMs?: number;
-    /** Give up on one report after this long in the pending/poll loop. */
+    /** Give up on the complete POST and polling operation after this long. */
     maxWaitMs?: number;
+    /** Cancel the operation early, such as during service shutdown. */
+    signal?: AbortSignal;
 }
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-export async function symbolicateMinidump(
+export function symbolicateMinidump(
     baseUrl: string,
     dump: Uint8Array,
     opts: SymbolicateOptions = {},
@@ -22,10 +26,10 @@ export async function symbolicateMinidump(
         'upload_file_minidump.dmp',
     );
 
-    return await submitAndPoll(baseUrl, '/minidump', form, opts);
+    return submitAndPoll(baseUrl, '/minidump', form, opts);
 }
 
-export async function symbolicateAppleCrashReport(
+export function symbolicateAppleCrashReport(
     baseUrl: string,
     reportText: string,
     opts: SymbolicateOptions = {},
@@ -37,7 +41,16 @@ export async function symbolicateAppleCrashReport(
         'apple_crash_report.crash',
     );
 
-    return await submitAndPoll(baseUrl, '/applecrashreport', form, opts);
+    return submitAndPoll(baseUrl, '/applecrashreport', form, opts);
+}
+
+async function responseError(context: string, response: Response) {
+    const detail = await response.text().catch(() => '');
+    logError('symbolicator_http_error', detail.slice(0, 500), {
+        context,
+        status: response.status,
+    });
+    return new Error(`${context}: ${response.status}`);
 }
 
 async function submitAndPoll(
@@ -49,47 +62,46 @@ async function submitAndPoll(
     const fetchFn = opts.fetchFn ?? fetch;
     const pollIntervalMs = opts.pollIntervalMs ?? 1000;
     const maxWaitMs = opts.maxWaitMs ?? 5 * 60 * 1000;
+    const deadline = AbortSignal.timeout(maxWaitMs);
+    const signal = opts.signal
+        ? AbortSignal.any([deadline, opts.signal])
+        : deadline;
 
-    const res = await fetchFn(`${baseUrl}${endpoint}`, {
-        method: 'POST',
-        body: form,
-    });
+    const res = await fetchFn(
+        `${baseUrl}${endpoint}?timeout=${REQUEST_TIMEOUT_SECONDS}`,
+        {
+            method: 'POST',
+            body: form,
+            signal,
+        },
+    );
     if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        throw new Error(
-            `symbolicator POST ${endpoint} failed: ${res.status} ${
-                text.slice(0, 500)
-            }`,
+        throw await responseError(
+            `symbolicator POST ${endpoint} failed`,
+            res,
         );
     }
 
     let body = await res.json() as SymbolicatorResponse;
 
-    const deadline = Date.now() + maxWaitMs;
     while (body.status === 'pending') {
         if (!body.request_id) {
             throw new Error('symbolicator returned pending without request_id');
         }
-        if (Date.now() > deadline) {
-            throw new Error('symbolicator request timed out while pending');
-        }
-
-        await sleep(
+        await delay(
             body.retry_after !== undefined
                 ? body.retry_after * 1000
                 : pollIntervalMs,
+            undefined,
+            { signal },
         );
 
         const poll = await fetchFn(
-            `${baseUrl}/requests/${body.request_id}?timeout=30`,
+            `${baseUrl}/requests/${body.request_id}?timeout=${REQUEST_TIMEOUT_SECONDS}`,
+            { signal },
         );
         if (!poll.ok) {
-            const text = await poll.text().catch(() => '');
-            throw new Error(
-                `symbolicator poll failed: ${poll.status} ${
-                    text.slice(0, 500)
-                }`,
-            );
+            throw await responseError('symbolicator poll failed', poll);
         }
 
         body = await poll.json() as SymbolicatorResponse;

--- a/svc/minidumpster/src/symbols.ts
+++ b/svc/minidumpster/src/symbols.ts
@@ -9,6 +9,7 @@ import { symbolsDir, tmpDir } from './paths.ts';
 import { streamMultipartToDisk } from './multipart.ts';
 
 const NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const SYMSORTER_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 export interface SymbolIngestResult {
     ok: true;
@@ -38,47 +39,63 @@ function bearerToken(req: Request): string | null {
     return m ? m[1].trim() : null;
 }
 
+function requireValidNames(product: string, version: string): void {
+    for (const [field, value] of [['product', product], ['version', version]]) {
+        if (!NAME_RE.test(value)) {
+            throw new HttpError(
+                400,
+                `missing or invalid '${field}' (query param or multipart field)`,
+            );
+        }
+    }
+}
+
 async function streamToFile(
     stream: ReadableStream<Uint8Array>,
     path: string,
-): Promise<number> {
-    const f = await Deno.open(path, {
+): Promise<void> {
+    const file = await Deno.open(path, {
         write: true,
         create: true,
         truncate: true,
+        mode: 0o600,
     });
-
-    let size = 0;
-    try {
-        for await (const chunk of stream) {
-            let off = 0;
-            while (off < chunk.length) {
-                off += await f.write(chunk.subarray(off));
-            }
-            size += chunk.length;
-        }
-    } finally {
-        f.close();
-    }
-
-    return size;
+    await stream.pipeTo(file.writable);
 }
 
 async function runSymsorter(
     bin: string,
     args: string[],
+    timeoutMs: number,
 ): Promise<{ code: number; output: string }> {
     const proc = new Deno.Command(bin, {
         args,
         stdout: 'piped',
         stderr: 'piped',
-    });
+    }).spawn();
 
-    const res = await proc.output();
-    const output = new TextDecoder().decode(res.stdout)
-        + new TextDecoder().decode(res.stderr);
-
-    return { code: res.code, output };
+    let timedOut = false;
+    const timer = setTimeout(() => {
+        timedOut = true;
+        try {
+            proc.kill('SIGKILL');
+        } catch {
+            // Process already exited.
+        }
+    }, timeoutMs);
+    try {
+        const { code, stdout, stderr } = await proc.output();
+        if (timedOut) {
+            throw new Error(`symsorter exceeded timeout of ${timeoutMs}ms`);
+        }
+        return {
+            code,
+            output: new TextDecoder().decode(stdout)
+                + new TextDecoder().decode(stderr),
+        };
+    } finally {
+        clearTimeout(timer);
+    }
 }
 
 async function sortSymbolDirectory(
@@ -90,10 +107,6 @@ async function sortSymbolDirectory(
     opts: SymbolsOptions,
     sourceBytes?: number,
 ): Promise<SymbolIngestResult> {
-    if (!NAME_RE.test(product) || !NAME_RE.test(version)) {
-        throw new HttpError(400, 'invalid symbol product or version');
-    }
-
     logEvent('symbols_extracted', {
         product,
         version,
@@ -106,15 +119,28 @@ async function sortSymbolDirectory(
     // <id[:2]>/<id[2:]>/<type> relative to the source root, so a product
     // prefix directory would make every lookup miss. Debug IDs are globally
     // unique. The bundle id tags this upload for retention bookkeeping.
-    const sorted = await runSymsorter(bin, [
-        '--output',
-        symbolsDir(config.dataDir),
-        '--bundle-id',
-        `${product}-${version}`,
-        inputDir,
-    ]).catch(() => {
-        throw new HttpError(500, 'symsorter is not installed on the server');
-    });
+    let sorted: { code: number; output: string };
+    try {
+        sorted = await runSymsorter(
+            bin,
+            [
+                '--output',
+                symbolsDir(config.dataDir),
+                '--bundle-id',
+                `${product}-${version}`,
+                inputDir,
+            ],
+            SYMSORTER_TIMEOUT_MS,
+        );
+    } catch (err) {
+        if (err instanceof Deno.errors.NotFound) {
+            throw new HttpError(
+                500,
+                'symsorter is not installed on the server',
+            );
+        }
+        throw err;
+    }
     if (sorted.code !== 0) {
         throw new HttpError(
             500,
@@ -152,18 +178,7 @@ async function processSymbolZip(
     config: Config,
     opts: SymbolsOptions,
 ): Promise<SymbolIngestResult> {
-    if (!NAME_RE.test(product)) {
-        throw new HttpError(
-            400,
-            "missing or invalid 'product' (query param or multipart field)",
-        );
-    }
-    if (!NAME_RE.test(version)) {
-        throw new HttpError(
-            400,
-            "missing or invalid 'version' (query param or multipart field)",
-        );
-    }
+    requireValidNames(product, version);
 
     const stat = await Deno.stat(zipPath).catch(() => null);
     if (!stat || stat.size === 0) {
@@ -177,7 +192,7 @@ async function processSymbolZip(
     });
 
     const extractDir = join(workDir, 'extracted');
-    await Deno.mkdir(extractDir);
+    await Deno.mkdir(extractDir, { mode: 0o700 });
 
     let filesExtracted: number;
     try {
@@ -194,7 +209,7 @@ async function processSymbolZip(
         throw new HttpError(400, 'zip archive contains no files');
     }
 
-    return await sortSymbolDirectory(
+    return sortSymbolDirectory(
         extractDir,
         product,
         version,
@@ -205,15 +220,16 @@ async function processSymbolZip(
     );
 }
 
-export async function handleSymbolUpload(
+async function handleSymbolUpload(
     req: Request,
     config: Config,
-    opts: SymbolsOptions = {},
+    opts: SymbolsOptions,
 ): Promise<SymbolIngestResult> {
     if (bearerToken(req) !== config.symbolUploadToken) {
         throw new HttpError(401, 'missing or invalid bearer token');
     }
-    if (!req.body) {
+    const body = req.body;
+    if (!body) {
         throw new HttpError(400, 'empty request body');
     }
 
@@ -238,14 +254,14 @@ export async function handleSymbolUpload(
         const contentType = req.headers.get('content-type') ?? '';
         if (contentType.toLowerCase().includes('multipart/form-data')) {
             const parsed = await streamMultipartToDisk(
-                req.body,
+                body,
                 contentType,
                 () => zipPath,
             ).catch((e) => {
-                throw new HttpError(
-                    400,
-                    e instanceof Error ? e.message : 'malformed multipart body',
-                );
+                const message = e instanceof Error
+                    ? e.message
+                    : 'malformed multipart body';
+                throw new HttpError(400, message);
             });
 
             product = parsed.fields['product'] || product;
@@ -254,7 +270,7 @@ export async function handleSymbolUpload(
                 throw new HttpError(400, 'no file part in multipart body');
             }
         } else {
-            await streamToFile(req.body, zipPath);
+            await streamToFile(body, zipPath);
         }
 
         return await processSymbolZip(
@@ -298,6 +314,7 @@ export async function ingestSymbolDirectory(
     db: Db,
     opts: SymbolsOptions = {},
 ): Promise<SymbolIngestAndRequeueResult> {
+    requireValidNames(product, version);
     if (filesExtracted < 1) {
         throw new HttpError(400, 'artifact contains no matching symbol files');
     }
@@ -357,3 +374,5 @@ export async function ingestSymbolUpload(
     const result = await handleSymbolUpload(req, config, opts);
     return requeueSymbolResult(result, db);
 }
+
+export const _test = { runSymsorter };

--- a/svc/minidumpster/src/templates/layout.eta
+++ b/svc/minidumpster/src/templates/layout.eta
@@ -4,12 +4,12 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><%= it.title %> · minidumpster</title>
-<link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/style.css">
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+<link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <header>
-  <a class="brand" href="/" aria-label="minidumpster"><img src="/favicon.svg" alt=""></a>
+  <a class="brand" href="/" aria-label="minidumpster"><img src="/static/favicon.svg" alt=""></a>
   <% if (!it.section || it.section === 'reports') { %>
   <span class="muted">crash reports</span>
   <% } else { %><a href="/">crash reports</a><% } %>
@@ -27,6 +27,6 @@
   <% } %>
 </header>
 <%~ it.body %>
-<script src="/app.js" defer></script>
+<script src="/static/app.js" defer></script>
 </body>
 </html>

--- a/svc/minidumpster/src/templates/layout.eta
+++ b/svc/minidumpster/src/templates/layout.eta
@@ -4,11 +4,12 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><%= it.title %> · minidumpster</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="stylesheet" href="/style.css">
 </head>
 <body>
 <header>
-  <h1><a href="/">minidumpster</a></h1>
+  <a class="brand" href="/" aria-label="minidumpster"><img src="/favicon.svg" alt=""></a>
   <% if (!it.section || it.section === 'reports') { %>
   <span class="muted">crash reports</span>
   <% } else { %><a href="/">crash reports</a><% } %>
@@ -26,16 +27,6 @@
   <% } %>
 </header>
 <%~ it.body %>
-<script>
-document.addEventListener('click', (e) => {
-  const t = e.target.closest('.expandable');
-  if (!t) {
-    return;
-  }
-  const full = t.dataset.full;
-  t.dataset.full = t.textContent;
-  t.textContent = full;
-});
-</script>
+<script src="/app.js" defer></script>
 </body>
 </html>

--- a/svc/minidumpster/src/templates/report.eta
+++ b/svc/minidumpster/src/templates/report.eta
@@ -25,15 +25,14 @@
 </p>
 
 <p>
-  <% if (it.report.dump_deleted) { %>
-  <span class="muted">raw payload deleted by retention</span>
-  <% } else { %>
   <a href="/reports/<%= it.report.id %>/dump">Download raw <%= it.report.kind === 'apple' ? 'crash report' : '.dmp' %></a>
-  <% } %>
   <% if (it.report.status === 'processed') { %>
   · <a href="/reports/<%= it.report.id %>/json">Download processed JSON</a>
   <% } %>
 </p>
+
+<h2>Retention</h2>
+<p class="muted">This report will be automatically deleted at <%= it.fmtTime(it.retentionDeadline) %>.</p>
 
 <h2>Annotations</h2>
 <div class="overflow">

--- a/svc/minidumpster/src/ui.ts
+++ b/svc/minidumpster/src/ui.ts
@@ -264,6 +264,7 @@ export function reportPage(
     report: ReportRow,
     group: GroupRow | null,
     stack: string | null,
+    retentionDeadline: number,
     user?: string,
 ): string {
     const annotations = Object.entries(
@@ -277,10 +278,11 @@ export function reportPage(
         group,
         stack,
         annotations,
+        retentionDeadline,
     });
 }
 
-export function uploadPage(user?: string, error?: string): string {
+export function uploadPage(user: string, error?: string): string {
     return render('upload', {
         title: 'Upload crash report',
         section: 'upload',

--- a/svc/minidumpster/src/worker.ts
+++ b/svc/minidumpster/src/worker.ts
@@ -124,10 +124,10 @@ export async function processReport(
 }
 
 export function startWorker(deps: WorkerDeps) {
-    const abort = new AbortController();
+    const controller = new AbortController();
     const signal = deps.signal
-        ? AbortSignal.any([abort.signal, deps.signal])
-        : abort.signal;
+        ? AbortSignal.any([controller.signal, deps.signal])
+        : controller.signal;
     const workerDeps = { ...deps, signal };
     const requeued = deps.db.resetProcessing();
     if (requeued > 0) {
@@ -178,7 +178,7 @@ export function startWorker(deps: WorkerDeps) {
 
     return {
         stop() {
-            abort.abort();
+            controller.abort();
             return loop;
         },
     };

--- a/svc/minidumpster/src/worker.ts
+++ b/svc/minidumpster/src/worker.ts
@@ -1,7 +1,10 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
 import type { Db, ReportRow } from './db.ts';
 import type { Config } from './config.ts';
 import { logError, logEvent } from './log.ts';
 import { normalizeAppleCrashReport } from './applecrash.ts';
+import { deleteReportAndPayload } from './reports.ts';
 import { dumpPath, processedPath, writeFileWithDirs } from './paths.ts';
 import {
     computeSignature,
@@ -18,6 +21,7 @@ export interface WorkerDeps {
     config: Config;
     fetchFn?: typeof fetch;
     pollIntervalMs?: number;
+    signal?: AbortSignal;
 }
 
 function backoffMs(attempts: number): number {
@@ -34,6 +38,7 @@ export async function processReport(
         const opts = {
             fetchFn: deps.fetchFn,
             pollIntervalMs: deps.pollIntervalMs,
+            signal: deps.signal,
         };
         const raw = await Deno.readFile(dumpPath(config.dataDir, report.id));
         const resp = report.kind === 'apple'
@@ -43,6 +48,14 @@ export async function processReport(
                 opts,
             )
             : await symbolicateMinidump(config.symbolicatorUrl, raw, opts);
+        if (resp.status === 'failed') {
+            deleteReportAndPayload(db, config, report.id);
+            logEvent('report_rejected', {
+                report_id: report.id,
+                attempts,
+            });
+            return;
+        }
         await writeFileWithDirs(
             processedPath(config.dataDir, report.id),
             JSON.stringify(resp),
@@ -55,13 +68,15 @@ export async function processReport(
         }))
             ?? (await fallbackSignature(resp));
         const now = Date.now();
+        const platform = platformFromResponse(resp);
         const groupId = db.upsertGroup(sig.signature, sig.title, now);
         db.markProcessed(
             report.id,
             groupId,
-            platformFromResponse(resp),
+            platform,
             now,
             sig.symbolicated,
+            attempts,
         );
         db.recountGroups([report.group_id, groupId]);
 
@@ -70,66 +85,101 @@ export async function processReport(
             group_id: groupId,
             product: report.product,
             version: report.version,
-            platform: platformFromResponse(resp),
+            platform,
             symbolicated: sig.symbolicated,
             attempts,
         });
     } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (attempts >= config.maxAttempts) {
-            db.markFailed(report.id, message, attempts);
-            logError('report_failed', err, { report_id: report.id, attempts });
-        } else {
+        if (deps.signal?.aborted) {
+            // Service shutdown is not a processing failure and must not consume
+            // the report's final retry. Make it immediately claimable on boot.
             db.markRetry(
                 report.id,
-                message,
-                attempts,
-                Date.now() + backoffMs(attempts),
+                'processing interrupted by shutdown',
+                report.attempts,
+                0,
             );
-            logError('report_retry', err, { report_id: report.id, attempts });
+            logEvent('report_requeued_shutdown', { report_id: report.id });
+            return;
         }
+
+        if (attempts >= config.maxAttempts) {
+            deleteReportAndPayload(db, config, report.id);
+            logError('report_discarded', err, {
+                report_id: report.id,
+                attempts,
+            });
+            return;
+        }
+
+        const message = err instanceof Error ? err.message : String(err);
+        db.markRetry(
+            report.id,
+            message,
+            attempts,
+            Date.now() + backoffMs(attempts),
+        );
+        logError('report_retry', err, { report_id: report.id, attempts });
     }
 }
 
-export interface WorkerHandle {
-    stop(): Promise<void>;
-}
-
-export function startWorker(deps: WorkerDeps): WorkerHandle {
-    let stopped = false;
+export function startWorker(deps: WorkerDeps) {
+    const abort = new AbortController();
+    const signal = deps.signal
+        ? AbortSignal.any([abort.signal, deps.signal])
+        : abort.signal;
+    const workerDeps = { ...deps, signal };
     const requeued = deps.db.resetProcessing();
     if (requeued > 0) {
         logEvent('worker_requeued_stuck', { count: requeued });
     }
 
     const loop = (async () => {
-        while (!stopped) {
-            let claimed: ReportRow[] = [];
+        while (!signal.aborted) {
+            let report: ReportRow | null = null;
             try {
-                claimed = deps.db.claimPending(4, Date.now());
+                report = deps.db.claimNext(Date.now());
             } catch (err) {
                 logError('worker_claim_error', err);
             }
 
-            for (const report of claimed) {
-                if (stopped) {
-                    break;
-                }
-                await processReport(deps, report);
+            if (!report) {
+                await delay(deps.config.workerPollMs, undefined, { signal })
+                    .catch((err) => {
+                        if (!signal.aborted) throw err;
+                    });
+                continue;
             }
 
-            if (claimed.length === 0) {
-                await new Promise((r) =>
-                    setTimeout(r, deps.config.workerPollMs)
-                );
+            try {
+                await processReport(workerDeps, report);
+            } catch (err) {
+                // A secondary failure (usually a database write) should not
+                // permanently terminate the only processing loop.
+                logError('worker_process_error', err, {
+                    report_id: report.id,
+                });
+                if (signal.aborted) break;
+                try {
+                    deps.db.markRetry(
+                        report.id,
+                        'worker failed to persist processing state',
+                        report.attempts,
+                        Date.now() + deps.config.workerPollMs,
+                    );
+                } catch (retryErr) {
+                    logError('worker_requeue_error', retryErr, {
+                        report_id: report.id,
+                    });
+                }
             }
         }
     })();
 
     return {
-        async stop() {
-            stopped = true;
-            await loop;
+        stop() {
+            abort.abort();
+            return loop;
         },
     };
 }

--- a/svc/minidumpster/src/zip.ts
+++ b/svc/minidumpster/src/zip.ts
@@ -3,7 +3,7 @@ import { configure, Reader, ZipReader } from '@zip-js/zip-js';
 
 configure({ useWebWorkers: false });
 
-class DenoFileReader extends Reader<Deno.FsFile> {
+export class DenoFileReader extends Reader<Deno.FsFile> {
     constructor(private file: Deno.FsFile) {
         super(file);
     }

--- a/svc/minidumpster/test/artifact_crawler_test.ts
+++ b/svc/minidumpster/test/artifact_crawler_test.ts
@@ -7,6 +7,50 @@ function json(data: unknown, status = 200): Response {
     return Response.json(data, { status });
 }
 
+function singleArtifactFetch(
+    size: number,
+    jobConclusion: string,
+): typeof fetch {
+    return (input) => {
+        const url = new URL(
+            typeof input === 'string' || input instanceof URL
+                ? input
+                : input.url,
+        );
+        if (url.pathname.endsWith('/releases')) {
+            return Promise.resolve(json([{ tag_name: '1.0', draft: false }]));
+        }
+        if (url.pathname.includes('/commits/')) {
+            return Promise.resolve(json({ sha: 'sha' }));
+        }
+        if (url.pathname.endsWith('/actions/artifacts')) {
+            const artifacts = url.pathname.includes('/helium-linux/')
+                ? [{
+                    id: 7,
+                    name: 'helium-symbols',
+                    size_in_bytes: size,
+                    created_at: new Date().toISOString(),
+                    expired: false,
+                    workflow_run: { id: 8, head_sha: 'sha' },
+                }]
+                : [];
+            return Promise.resolve(json({
+                total_count: artifacts.length,
+                artifacts,
+            }));
+        }
+        if (url.pathname.endsWith('/actions/runs/8/jobs')) {
+            return Promise.resolve(json({
+                jobs: [{
+                    name: 'Create release',
+                    conclusion: jobConclusion,
+                }],
+            }));
+        }
+        throw new Error(`unexpected request: ${url}`);
+    };
+}
+
 Deno.test('crawler classifies platform build artifacts and symbol archives', () => {
     const symbols = /symbols/i;
     assertEquals(
@@ -69,12 +113,14 @@ Deno.test('crawler stops the pass when GitHub is rate limited', async () => {
     }
 });
 
-Deno.test('crawler ingests symbol artifacts from release-producing runs once', async () => {
+Deno.test('crawler resumes a rate-limited symbol artifact download', async () => {
     const env = await makeTestEnv({
         githubArtifactToken: 'github-artifact-token',
     });
     try {
         let uploads = 0;
+        let downloadRateLimited = true;
+        let now = 1_000_000;
         const fetchMock: typeof fetch = (input, init) => {
             const url = new URL(
                 typeof input === 'string' || input instanceof URL
@@ -162,6 +208,15 @@ Deno.test('crawler ingests symbol artifacts from release-producing runs once', a
                     }));
                 }
                 if (url.pathname.endsWith('/actions/artifacts/42/zip')) {
+                    if (downloadRateLimited) {
+                        downloadRateLimited = false;
+                        return Promise.resolve(
+                            new Response('rate limited', {
+                                status: 403,
+                                headers: { 'x-ratelimit-remaining': '0' },
+                            }),
+                        );
+                    }
                     return Promise.resolve(
                         new Response(new Uint8Array([80, 75, 3, 4]), {
                             headers: { 'content-length': '4' },
@@ -177,7 +232,7 @@ Deno.test('crawler ingests symbol artifacts from release-producing runs once', a
             config: env.config,
             fetchFn: fetchMock,
             githubApiUrl: 'https://api.test',
-            now: () => 1_000_000,
+            now: () => now,
             ingestFn: async (
                 body: ReadableStream<Uint8Array>,
                 product: string,
@@ -204,6 +259,7 @@ Deno.test('crawler ingests symbol artifacts from release-producing runs once', a
             },
         };
         await crawlArtifactsOnce(deps);
+        now += env.config.artifactCrawlerPollMs;
         await crawlArtifactsOnce(deps);
 
         assertEquals(uploads, 1);
@@ -226,50 +282,37 @@ Deno.test('crawler ignores artifacts from runs without a successful release job'
         githubArtifactToken: 'github-artifact-token',
     });
     try {
-        const fetchMock: typeof fetch = (input) => {
-            const url = new URL(
-                typeof input === 'string' || input instanceof URL
-                    ? input
-                    : input.url,
-            );
-            if (url.pathname.endsWith('/releases')) {
-                return Promise.resolve(
-                    json([{ tag_name: '1.0', draft: false }]),
-                );
-            }
-            if (url.pathname.includes('/commits/')) {
-                return Promise.resolve(json({ sha: 'sha' }));
-            }
-            if (url.pathname.endsWith('/actions/artifacts')) {
-                const isLinux = url.pathname.includes('/helium-linux/');
-                return Promise.resolve(json({
-                    total_count: isLinux ? 1 : 0,
-                    artifacts: isLinux
-                        ? [{
-                            id: 7,
-                            name: 'helium-symbols',
-                            size_in_bytes: 100,
-                            created_at: new Date().toISOString(),
-                            expired: false,
-                            workflow_run: { id: 8, head_sha: 'sha' },
-                        }]
-                        : [],
-                }));
-            }
-            if (url.pathname.endsWith('/actions/runs/8/jobs')) {
-                return Promise.resolve(json({
-                    jobs: [{ name: 'Create release', conclusion: 'skipped' }],
-                }));
-            }
-            throw new Error(`unexpected request: ${url}`);
-        };
-
         await crawlArtifactsOnce({
             db: env.db,
             config: env.config,
-            fetchFn: fetchMock,
+            fetchFn: singleArtifactFetch(100, 'skipped'),
             githubApiUrl: 'https://api.test',
         });
+        assertEquals(
+            env.db.getArtifactIngest('imputnet/helium-linux', 7),
+            null,
+        );
+    } finally {
+        await env.cleanup();
+    }
+});
+
+Deno.test('crawler ignores artifacts larger than its configured download size', async () => {
+    const env = await makeTestEnv({
+        githubArtifactToken: 'github-artifact-token',
+        artifactCrawlerMaxBytes: 100,
+    });
+    try {
+        const deps = {
+            db: env.db,
+            config: env.config,
+            fetchFn: singleArtifactFetch(101, 'success'),
+            githubApiUrl: 'https://api.test',
+            ingestFn: () => Promise.reject(new Error('should not ingest')),
+        };
+
+        await crawlArtifactsOnce(deps);
+        await crawlArtifactsOnce(deps);
         assertEquals(
             env.db.getArtifactIngest('imputnet/helium-linux', 7),
             null,

--- a/svc/minidumpster/test/auth_test.ts
+++ b/svc/minidumpster/test/auth_test.ts
@@ -7,21 +7,23 @@ import { decodeSession, encodeSession } from '../src/session.ts';
 
 Deno.test('session payloads round-trip and reject malformed/expired values', () => {
     const now = Date.now();
-    const ok = decodeSession(
-        encodeSession({ login: 'jj', exp: now + 60_000 }),
-        now,
-    );
+    const valid = {
+        login: 'jj',
+        exp: now + 60_000,
+    };
+    const ok = decodeSession(encodeSession(valid), now);
     assert(ok);
     assertEquals(ok.login, 'jj');
 
-    assertEquals(decodeSession(undefined, now), null);
-    assertEquals(decodeSession(false, now), null);
-    assertEquals(decodeSession('not json', now), null);
-    assertEquals(decodeSession(JSON.stringify({ login: 'jj' }), now), null);
-    assertEquals(
-        decodeSession(encodeSession({ login: 'jj', exp: now - 1 }), now),
-        null,
-    );
+    const rejects = (
+        value: Parameters<typeof decodeSession>[0],
+        at = now,
+    ) => assertEquals(decodeSession(value, at), null);
+    rejects(undefined);
+    rejects(false);
+    rejects('not json');
+    rejects(JSON.stringify({ login: 'jj' }));
+    rejects(encodeSession({ ...valid, exp: now - 1 }));
 });
 
 /** Mock of the GitHub endpoints hit during login (middleware + org gate). */
@@ -126,6 +128,9 @@ Deno.test('OAuth callback grants a session to active org members', async () => {
             assertEquals(res.headers.get('location'), '/');
             const setCookie = res.headers.get('set-cookie') ?? '';
             assert(setCookie.includes('session='));
+            assert(setCookie.includes('Max-Age=604800'));
+            assert(setCookie.includes('HttpOnly'));
+            assert(setCookie.includes('SameSite=Lax'));
 
             // The issued (signed) session cookie opens the UI.
             const sessionValue = /session=([^;]+)/.exec(setCookie)![1];
@@ -133,7 +138,16 @@ Deno.test('OAuth callback grants a session to active org members', async () => {
                 headers: { cookie: `session=${sessionValue}` },
             });
             assertEquals(home.status, 200);
-            assert((await home.text()).includes('minidumpster'));
+            assertEquals(
+                home.headers.get('content-security-policy')?.includes(
+                    "script-src 'self' 'unsafe-inline'",
+                ),
+                false,
+            );
+            const homeHtml = await home.text();
+            assert(homeHtml.includes('minidumpster'));
+            assert(homeHtml.includes('<script src="/app.js" defer></script>'));
+            assertEquals(homeHtml.includes('<script>'), false);
 
             env.db.registerArtifact(
                 'imputnet/helium-windows',
@@ -233,18 +247,51 @@ Deno.test('UI routes redirect to login without a session', async () => {
     }
 });
 
-Deno.test('the stylesheet is served without a session', async () => {
+Deno.test('shared page assets are served without a session', async () => {
     const env = await makeTestEnv();
     try {
         const app = buildApp({ config: env.config, db: env.db });
 
         const res = await app.request('/style.css');
         assertEquals(res.status, 200);
+        assertEquals(res.headers.get('x-content-type-options'), 'nosniff');
+        assert(
+            (res.headers.get('content-security-policy') ?? '').includes(
+                "default-src 'none'",
+            ),
+        );
+        assert(
+            (res.headers.get('content-security-policy') ?? '').includes(
+                "script-src 'self'",
+            ),
+        );
+        assertEquals(
+            res.headers.get('content-security-policy')?.includes(
+                "script-src 'self' 'unsafe-inline'",
+            ),
+            false,
+        );
         assertEquals(
             res.headers.get('content-type'),
             'text/css; charset=utf-8',
         );
         assert((await res.text()).includes('.expandable'));
+
+        const favicon = await app.request('/favicon.svg');
+        assertEquals(favicon.status, 200);
+        assertEquals(
+            favicon.headers.get('content-type'),
+            'image/svg+xml; charset=utf-8',
+        );
+        assert((await favicon.text()).startsWith('<svg'));
+
+        const script = await app.request('/app.js');
+        assertEquals(script.status, 200);
+        assertEquals(
+            script.headers.get('content-type'),
+            'text/javascript; charset=utf-8',
+        );
+        assert((await script.text()).includes('addEventListener'));
 
         // Everything else stays gated.
         const page = await app.request('/');

--- a/svc/minidumpster/test/auth_test.ts
+++ b/svc/minidumpster/test/auth_test.ts
@@ -146,7 +146,11 @@ Deno.test('OAuth callback grants a session to active org members', async () => {
             );
             const homeHtml = await home.text();
             assert(homeHtml.includes('minidumpster'));
-            assert(homeHtml.includes('<script src="/app.js" defer></script>'));
+            assert(
+                homeHtml.includes(
+                    '<script src="/static/app.js" defer></script>',
+                ),
+            );
             assertEquals(homeHtml.includes('<script>'), false);
 
             env.db.registerArtifact(
@@ -252,7 +256,7 @@ Deno.test('shared page assets are served without a session', async () => {
     try {
         const app = buildApp({ config: env.config, db: env.db });
 
-        const res = await app.request('/style.css');
+        const res = await app.request('/static/style.css');
         assertEquals(res.status, 200);
         assertEquals(res.headers.get('x-content-type-options'), 'nosniff');
         assert(
@@ -277,7 +281,7 @@ Deno.test('shared page assets are served without a session', async () => {
         );
         assert((await res.text()).includes('.expandable'));
 
-        const favicon = await app.request('/favicon.svg');
+        const favicon = await app.request('/static/favicon.svg');
         assertEquals(favicon.status, 200);
         assertEquals(
             favicon.headers.get('content-type'),
@@ -285,7 +289,7 @@ Deno.test('shared page assets are served without a session', async () => {
         );
         assert((await favicon.text()).startsWith('<svg'));
 
-        const script = await app.request('/app.js');
+        const script = await app.request('/static/app.js');
         assertEquals(script.status, 200);
         assertEquals(
             script.headers.get('content-type'),

--- a/svc/minidumpster/test/build_artifacts_test.ts
+++ b/svc/minidumpster/test/build_artifacts_test.ts
@@ -126,6 +126,37 @@ Deno.test('artifact downloads do not retry streamed size violations', async () =
     }
 });
 
+Deno.test('artifact downloads reject a size header that exceeds metadata', async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+        let requests = 0;
+        const fetchMock: typeof fetch = () => {
+            requests++;
+            return Promise.resolve(
+                new Response(new Uint8Array([1, 2, 3]), {
+                    headers: { 'content-length': '3' },
+                }),
+            );
+        };
+
+        await assertRejects(
+            () =>
+                _test.downloadArtifact(
+                    'https://example.test/artifact.zip',
+                    2,
+                    'token',
+                    join(dir, 'artifact.zip'),
+                    fetchMock,
+                ),
+            Error,
+            'exceeds its declared metadata size',
+        );
+        assertEquals(requests, 1);
+    } finally {
+        await Deno.remove(dir, { recursive: true });
+    }
+});
+
 Deno.test('artifact downloads retry transient connection failures', async () => {
     const dir = await Deno.makeTempDir();
     try {

--- a/svc/minidumpster/test/build_artifacts_test.ts
+++ b/svc/minidumpster/test/build_artifacts_test.ts
@@ -1,0 +1,208 @@
+import { join } from '@std/path';
+import { assertEquals, assertRejects } from '@std/assert';
+
+import { _test } from '../src/build-artifacts.ts';
+import { makeZip } from './helpers.ts';
+
+function writeString(
+    target: Uint8Array,
+    offset: number,
+    length: number,
+    value: string,
+): void {
+    target.set(new TextEncoder().encode(value).slice(0, length), offset);
+}
+
+function writeOctal(
+    target: Uint8Array,
+    offset: number,
+    length: number,
+    value: number,
+): void {
+    writeString(
+        target,
+        offset,
+        length,
+        value.toString(8).padStart(length - 1, '0') + '\0',
+    );
+}
+
+function tarEntry(
+    name: string,
+    data: Uint8Array,
+): Uint8Array {
+    const header = new Uint8Array(512);
+    writeString(header, 0, 100, name);
+    writeOctal(header, 100, 8, 0o600);
+    writeOctal(header, 108, 8, 0);
+    writeOctal(header, 116, 8, 0);
+    writeOctal(header, 124, 12, data.byteLength);
+    writeOctal(header, 136, 12, 0);
+    header.fill(0x20, 148, 156);
+    header[156] = '0'.charCodeAt(0);
+    writeString(header, 257, 6, 'ustar\0');
+    writeString(header, 263, 2, '00');
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    writeString(
+        header,
+        148,
+        8,
+        checksum.toString(8).padStart(6, '0') + '\0 ',
+    );
+
+    const padded = Math.ceil(data.byteLength / 512) * 512;
+    const result = new Uint8Array(512 + padded);
+    result.set(header);
+    result.set(data, 512);
+    return result;
+}
+
+function makeTar(entries: Uint8Array[]): Uint8Array {
+    const length = entries.reduce((sum, entry) => sum + entry.length, 0);
+    const tar = new Uint8Array(length + 1024);
+    let offset = 0;
+    for (const entry of entries) {
+        tar.set(entry, offset);
+        offset += entry.length;
+    }
+    return tar;
+}
+
+/** A standards-compliant Zstandard frame containing only raw blocks. */
+function rawZstd(data: Uint8Array): Uint8Array {
+    const maxBlock = 128 * 1024;
+    const blocks = Math.ceil(data.byteLength / maxBlock);
+    const frame = new Uint8Array(6 + data.byteLength + blocks * 3);
+    frame.set([0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x38]);
+    let input = 0;
+    let output = 6;
+    while (input < data.byteLength) {
+        const size = Math.min(maxBlock, data.byteLength - input);
+        const last = input + size === data.byteLength;
+        const header = size * 8 + (last ? 1 : 0);
+        frame[output++] = header & 0xff;
+        frame[output++] = (header >>> 8) & 0xff;
+        frame[output++] = (header >>> 16) & 0xff;
+        frame.set(data.subarray(input, input + size), output);
+        output += size;
+        input += size;
+    }
+    return frame;
+}
+
+Deno.test('artifact downloads do not retry streamed size violations', async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+        let requests = 0;
+        const fetchMock: typeof fetch = () => {
+            requests++;
+            return Promise.resolve(
+                new Response(
+                    new ReadableStream<Uint8Array>({
+                        start(controller) {
+                            controller.enqueue(new Uint8Array([1, 2, 3]));
+                            controller.close();
+                        },
+                    }),
+                ),
+            );
+        };
+
+        await assertRejects(
+            () =>
+                _test.downloadArtifact(
+                    'https://example.test/artifact.zip',
+                    2,
+                    'token',
+                    join(dir, 'artifact.zip'),
+                    fetchMock,
+                ),
+            Error,
+            'exceeded expected size',
+        );
+        assertEquals(requests, 1);
+    } finally {
+        await Deno.remove(dir, { recursive: true });
+    }
+});
+
+Deno.test('artifact downloads retry transient connection failures', async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+        let requests = 0;
+        const fetchMock: typeof fetch = () => {
+            requests++;
+            if (requests === 1) {
+                return Promise.reject(new TypeError('connection reset'));
+            }
+            return Promise.resolve(
+                new Response(new Uint8Array([1, 2]), {
+                    headers: { 'content-length': '2' },
+                }),
+            );
+        };
+        const artifact = join(dir, 'artifact.zip');
+        await _test.downloadArtifact(
+            'https://example.test/artifact.zip',
+            2,
+            'token',
+            artifact,
+            fetchMock,
+        );
+        assertEquals(requests, 2);
+        assertEquals(await Deno.readFile(artifact), new Uint8Array([1, 2]));
+    } finally {
+        await Deno.remove(dir, { recursive: true });
+    }
+});
+
+Deno.test('Windows nested artifacts extract selected files', async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+        const nested = await makeZip([
+            ['src/out/Default/helium.pdb', new TextEncoder().encode('pdb!')],
+            ['src/out/Default/ignored.txt', new Uint8Array([1])],
+        ], 0);
+        const outer = await makeZip([['artifacts.zip', nested]], 0);
+        const artifact = join(dir, 'windows.zip');
+        await Deno.writeFile(artifact, outer);
+
+        const out = join(dir, 'selected');
+        await Deno.mkdir(out);
+        assertEquals(
+            await _test.extractBuild(artifact, out, 'windows-build'),
+            1,
+        );
+        assertEquals(await Deno.readTextFile(join(out, 'helium.pdb')), 'pdb!');
+    } finally {
+        await Deno.remove(dir, { recursive: true });
+    }
+});
+
+Deno.test('macOS zstd/tar extraction selects build files', async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+        const filePath = 'src/out/Default/Helium.app/Contents/MacOS/Helium';
+        const tar = makeTar([
+            tarEntry(filePath, new TextEncoder().encode('app!')),
+        ]);
+        const artifact = join(dir, 'mac.zip');
+        await Deno.writeFile(
+            artifact,
+            await makeZip([['build_src.tar.zst', rawZstd(tar)]], 0),
+        );
+
+        const out = join(dir, 'mac-selected');
+        await Deno.mkdir(out);
+        assertEquals(
+            await _test.extractBuild(artifact, out, 'mac-build'),
+            1,
+        );
+        assertEquals(
+            await Deno.readTextFile(join(out, filePath)),
+            'app!',
+        );
+    } finally {
+        await Deno.remove(dir, { recursive: true });
+    }
+});

--- a/svc/minidumpster/test/db_test.ts
+++ b/svc/minidumpster/test/db_test.ts
@@ -1,0 +1,63 @@
+import { assertEquals } from '@std/assert';
+import { join } from '@std/path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { Db } from '../src/db.ts';
+
+Deno.test('database migration removes the legacy dump_deleted column', async () => {
+    const dir = await Deno.makeTempDir();
+    const path = join(dir, 'db.sqlite');
+    try {
+        const legacy = new DatabaseSync(path);
+        try {
+            legacy.exec(`
+                CREATE TABLE reports (
+                    id TEXT PRIMARY KEY,
+                    group_id INTEGER,
+                    product TEXT,
+                    version TEXT,
+                    platform TEXT,
+                    guid TEXT,
+                    ptype TEXT,
+                    channel TEXT,
+                    annotations TEXT NOT NULL DEFAULT '{}',
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    error TEXT,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    next_attempt_at INTEGER NOT NULL DEFAULT 0,
+                    received_at INTEGER NOT NULL,
+                    processed_at INTEGER,
+                    dump_deleted INTEGER NOT NULL DEFAULT 0,
+                    kind TEXT NOT NULL DEFAULT 'minidump',
+                    symbolicated INTEGER NOT NULL DEFAULT 1
+                );
+                CREATE INDEX idx_reports_status ON reports(status);
+                INSERT INTO reports (id, status, received_at, dump_deleted)
+                VALUES ('legacy-report', 'processed', 1234, 1);
+            `);
+        } finally {
+            legacy.close();
+        }
+
+        const db = new Db(path);
+        try {
+            assertEquals(db.getReport('legacy-report')?.status, 'processed');
+        } finally {
+            db.close();
+        }
+
+        const migrated = new DatabaseSync(path);
+        try {
+            const legacyColumn = migrated.prepare(`
+                SELECT 1
+                FROM pragma_table_info('reports')
+                WHERE name = 'dump_deleted'
+            `).get();
+            assertEquals(legacyColumn, undefined);
+        } finally {
+            migrated.close();
+        }
+    } finally {
+        await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+});

--- a/svc/minidumpster/test/helpers.ts
+++ b/svc/minidumpster/test/helpers.ts
@@ -33,6 +33,12 @@ export function testConfig(
     };
 }
 
+export function minimalMinidump(): Uint8Array {
+    const dump = new Uint8Array(32);
+    dump.set([0x4d, 0x44, 0x4d, 0x50]);
+    return dump;
+}
+
 export interface TestEnv {
     dir: string;
     config: Config;

--- a/svc/minidumpster/test/helpers.ts
+++ b/svc/minidumpster/test/helpers.ts
@@ -3,6 +3,12 @@ import { Db } from '../src/db.ts';
 import { dbPath, ensureDataDirs } from '../src/paths.ts';
 import { encodeSession } from '../src/session.ts';
 import { serializeSigned } from 'hono/utils/cookie';
+import {
+    BlobWriter,
+    TextReader,
+    Uint8ArrayReader,
+    ZipWriter,
+} from '@zip-js/zip-js';
 
 export function testConfig(
     dataDir: string,
@@ -65,6 +71,23 @@ export async function dirEntries(path: string): Promise<string[]> {
         entries.push(entry.name);
     }
     return entries;
+}
+
+export async function makeZip(
+    entries: [string, Uint8Array | string][],
+    level?: number,
+): Promise<Uint8Array> {
+    const writer = new ZipWriter(new BlobWriter('application/zip'));
+    for (const [name, data] of entries) {
+        await writer.add(
+            name,
+            typeof data === 'string'
+                ? new TextReader(data)
+                : new Uint8ArrayReader(data),
+            level === undefined ? {} : { level },
+        );
+    }
+    return new Uint8Array(await (await writer.close()).arrayBuffer());
 }
 
 export async function testSessionCookie(env: TestEnv): Promise<string> {

--- a/svc/minidumpster/test/helpers.ts
+++ b/svc/minidumpster/test/helpers.ts
@@ -1,6 +1,8 @@
 import type { Config } from '../src/config.ts';
 import { Db } from '../src/db.ts';
 import { dbPath, ensureDataDirs } from '../src/paths.ts';
+import { encodeSession } from '../src/session.ts';
+import { serializeSigned } from 'hono/utils/cookie';
 
 export function testConfig(
     dataDir: string,
@@ -37,6 +39,46 @@ export function minimalMinidump(): Uint8Array {
     const dump = new Uint8Array(32);
     dump.set([0x4d, 0x44, 0x4d, 0x50]);
     return dump;
+}
+
+/** Re-stream bytes in small chunks so parsers cannot rely on chunk boundaries. */
+export function chunked(
+    bytes: Uint8Array,
+    size: number,
+): ReadableStream<Uint8Array> {
+    let offset = 0;
+    return new ReadableStream({
+        pull(controller) {
+            if (offset >= bytes.byteLength) {
+                controller.close();
+                return;
+            }
+            controller.enqueue(bytes.slice(offset, offset + size));
+            offset += size;
+        },
+    });
+}
+
+export async function dirEntries(path: string): Promise<string[]> {
+    const entries: string[] = [];
+    for await (const entry of Deno.readDir(path)) {
+        entries.push(entry.name);
+    }
+    return entries;
+}
+
+export async function testSessionCookie(env: TestEnv): Promise<string> {
+    const now = Date.now();
+    const value = encodeSession({
+        login: 'jj',
+        exp: now + 60_000,
+    });
+    const cookie = await serializeSigned(
+        'session',
+        value,
+        env.config.sessionSecret,
+    );
+    return cookie.split(';')[0];
 }
 
 export interface TestEnv {

--- a/svc/minidumpster/test/multipart_test.ts
+++ b/svc/minidumpster/test/multipart_test.ts
@@ -87,3 +87,29 @@ Deno.test('streaming multipart parser rejects a missing boundary', async () => {
     }
     assert(threw, 'content-type without boundary should throw');
 });
+
+Deno.test('streaming multipart parser caps the complete body', async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+        const form = new FormData();
+        form.append(
+            'file',
+            new Blob([new Uint8Array(16 * 1024 * 1024)]),
+            'large.bin',
+        );
+        const { bytes, contentType } = await encodeMultipart(form);
+        let threw = false;
+        try {
+            await streamMultipartToDisk(
+                chunked(bytes, 64 * 1024),
+                contentType,
+                () => join(dir, 'limited.bin'),
+            );
+        } catch {
+            threw = true;
+        }
+        assert(threw, 'multipart body over the limit should throw');
+    } finally {
+        await Deno.remove(dir, { recursive: true });
+    }
+});

--- a/svc/minidumpster/test/multipart_test.ts
+++ b/svc/minidumpster/test/multipart_test.ts
@@ -88,7 +88,7 @@ Deno.test('streaming multipart parser rejects a missing boundary', async () => {
     assert(threw, 'content-type without boundary should throw');
 });
 
-Deno.test('streaming multipart parser caps the complete body', async () => {
+Deno.test('streaming multipart parser does not cap the complete body', async () => {
     const dir = await Deno.makeTempDir();
     try {
         const form = new FormData();
@@ -98,17 +98,12 @@ Deno.test('streaming multipart parser caps the complete body', async () => {
             'large.bin',
         );
         const { bytes, contentType } = await encodeMultipart(form);
-        let threw = false;
-        try {
-            await streamMultipartToDisk(
-                chunked(bytes, 64 * 1024),
-                contentType,
-                () => join(dir, 'limited.bin'),
-            );
-        } catch {
-            threw = true;
-        }
-        assert(threw, 'multipart body over the limit should throw');
+        const result = await streamMultipartToDisk(
+            chunked(bytes, 64 * 1024),
+            contentType,
+            () => join(dir, 'large.bin'),
+        );
+        assertEquals(result.files[0].size, 16 * 1024 * 1024);
     } finally {
         await Deno.remove(dir, { recursive: true });
     }

--- a/svc/minidumpster/test/symbolicator_test.ts
+++ b/svc/minidumpster/test/symbolicator_test.ts
@@ -1,0 +1,183 @@
+import { assert, assertEquals, assertRejects } from '@std/assert';
+
+import { symbolicateMinidump } from '../src/symbolicator.ts';
+import { minimalMinidump } from './helpers.ts';
+
+const completed = { status: 'completed', stacktraces: [] };
+
+function abortingFetch(
+    inspect: (signal: AbortSignal, url: string) => void = () => {},
+): typeof fetch {
+    return ((input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        assert(signal instanceof AbortSignal);
+        const url = String(input);
+        inspect(signal, url);
+        return new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener('abort', () => reject(signal.reason), {
+                once: true,
+            });
+        });
+    }) as typeof fetch;
+}
+
+Deno.test('Symbolicator deadline covers the initial POST', async () => {
+    const signals: AbortSignal[] = [];
+    const err = await assertRejects(() =>
+        symbolicateMinidump('http://symbolicator.test', minimalMinidump(), {
+            fetchFn: abortingFetch((signal) => signals.push(signal)),
+            maxWaitMs: 10,
+        })
+    );
+    assert(signals[0].aborted);
+    assert(err instanceof Error);
+    assertEquals(err.name, 'TimeoutError');
+});
+
+Deno.test('Symbolicator deadline remains active while reading POST JSON', async () => {
+    const signals: AbortSignal[] = [];
+    const fetchFn = ((_input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        assert(signal instanceof AbortSignal);
+        signals.push(signal);
+        const body = new ReadableStream({
+            start(controller) {
+                signal.addEventListener(
+                    'abort',
+                    () => controller.error(signal.reason),
+                    { once: true },
+                );
+            },
+        });
+        return Promise.resolve(
+            new Response(body, {
+                headers: { 'content-type': 'application/json' },
+            }),
+        );
+    }) as typeof fetch;
+
+    const err = await assertRejects(() =>
+        symbolicateMinidump('http://symbolicator.test', minimalMinidump(), {
+            fetchFn,
+            maxWaitMs: 10,
+        })
+    );
+    assert(signals[0].aborted);
+    assert(err instanceof Error);
+    assertEquals(err.name, 'TimeoutError');
+});
+
+Deno.test('Symbolicator deadline aborts an excessive retry_after', async () => {
+    let calls = 0;
+    const fetchFn = ((_input: string | URL | Request, init?: RequestInit) => {
+        assert(init?.signal instanceof AbortSignal);
+        calls++;
+        return Promise.resolve(Response.json({
+            status: 'pending',
+            request_id: 'request-1',
+            retry_after: 60,
+        }));
+    }) as typeof fetch;
+
+    const err = await assertRejects(() =>
+        symbolicateMinidump('http://symbolicator.test', minimalMinidump(), {
+            fetchFn,
+            maxWaitMs: 10,
+        })
+    );
+    assertEquals(calls, 1);
+    assert(err instanceof Error);
+    assertEquals(err.name, 'AbortError');
+});
+
+Deno.test('Symbolicator reuses one deadline signal for POST and polling', async () => {
+    const signals: AbortSignal[] = [];
+    const urls: string[] = [];
+    const fetchFn = ((input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        assert(signal instanceof AbortSignal);
+        signals.push(signal);
+        urls.push(String(input));
+        if (signals.length === 1) {
+            return Promise.resolve(Response.json({
+                status: 'pending',
+                request_id: 'request-1',
+                retry_after: 0,
+            }));
+        }
+        return Promise.resolve(Response.json(completed));
+    }) as typeof fetch;
+
+    const result = await symbolicateMinidump(
+        'http://symbolicator.test',
+        minimalMinidump(),
+        { fetchFn, maxWaitMs: 1000 },
+    );
+    assertEquals(result.status, 'completed');
+    assertEquals(signals.length, 2);
+    assert(signals[0] === signals[1]);
+    assertEquals(
+        urls,
+        [
+            'http://symbolicator.test/minidump?timeout=300',
+            'http://symbolicator.test/requests/request-1?timeout=300',
+        ],
+    );
+});
+
+Deno.test('Symbolicator HTTP errors do not expose response details', async () => {
+    const err = await assertRejects(
+        () =>
+            symbolicateMinidump(
+                'http://symbolicator.test',
+                minimalMinidump(),
+                {
+                    fetchFn: (() =>
+                        Promise.resolve(
+                            new Response('sensitive upstream detail', {
+                                status: 400,
+                            }),
+                        )) as typeof fetch,
+                },
+            ),
+        Error,
+        'symbolicator POST /minidump failed: 400',
+    );
+    assert(!err.message.includes('sensitive upstream detail'));
+});
+
+Deno.test('Symbolicator deadline covers a hanging poll request', async () => {
+    let postSignal: AbortSignal | null = null;
+    let pollSignal: AbortSignal | null = null;
+    let calls = 0;
+    const pendingThenHang = ((
+        input: string | URL | Request,
+        init?: RequestInit,
+    ) => {
+        const signal = init?.signal;
+        assert(signal instanceof AbortSignal);
+        calls++;
+        if (calls === 1) {
+            postSignal = signal;
+            return Promise.resolve(Response.json({
+                status: 'pending',
+                request_id: 'request-1',
+                retry_after: 0,
+            }));
+        }
+        return abortingFetch((seen, url) => {
+            pollSignal = seen;
+            assert(url.includes('/requests/request-1'));
+        })(input, init);
+    }) as typeof fetch;
+
+    const err = await assertRejects(() =>
+        symbolicateMinidump('http://symbolicator.test', minimalMinidump(), {
+            fetchFn: pendingThenHang,
+            maxWaitMs: 10,
+        })
+    );
+    assert(postSignal === pollSignal);
+    assert(err instanceof Error);
+    assertEquals(err.name, 'TimeoutError');
+});

--- a/svc/minidumpster/test/symbols_test.ts
+++ b/svc/minidumpster/test/symbols_test.ts
@@ -1,7 +1,8 @@
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertRejects } from '@std/assert';
 
 import { buildApp } from '../src/app.ts';
 import { makeTestEnv } from './helpers.ts';
+import { _test } from '../src/symbols.ts';
 
 Deno.test('POST /api/symbols requires the bearer token', async () => {
     const env = await makeTestEnv();
@@ -49,4 +50,17 @@ Deno.test('POST /api/symbols requires product and version', async () => {
     } finally {
         await env.cleanup();
     }
+});
+
+Deno.test('symsorter enforces a timeout', async () => {
+    await assertRejects(
+        () =>
+            _test.runSymsorter(
+                Deno.execPath(),
+                ['eval', 'await new Promise(r => setTimeout(r, 5000))'],
+                50,
+            ),
+        Error,
+        'symsorter exceeded timeout',
+    );
 });

--- a/svc/minidumpster/test/ui_test.ts
+++ b/svc/minidumpster/test/ui_test.ts
@@ -79,6 +79,16 @@ Deno.test('groupsPage renders populated rows', () => {
     assert(html.includes('<span class="pill">macOS</span>'));
     assert(html.includes('missing symbols'));
     assert(html.includes('jj'));
+    assert(
+        html.includes(
+            '<link rel="icon" type="image/svg+xml" href="/favicon.svg">',
+        ),
+    );
+    assert(
+        html.includes(
+            '<a class="brand" href="/" aria-label="minidumpster"><img src="/favicon.svg" alt=""></a>',
+        ),
+    );
 });
 
 Deno.test('symbolsPage renders release and installed bundle state', () => {

--- a/svc/minidumpster/test/ui_test.ts
+++ b/svc/minidumpster/test/ui_test.ts
@@ -81,12 +81,12 @@ Deno.test('groupsPage renders populated rows', () => {
     assert(html.includes('jj'));
     assert(
         html.includes(
-            '<link rel="icon" type="image/svg+xml" href="/favicon.svg">',
+            '<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">',
         ),
     );
     assert(
         html.includes(
-            '<a class="brand" href="/" aria-label="minidumpster"><img src="/favicon.svg" alt=""></a>',
+            '<a class="brand" href="/" aria-label="minidumpster"><img src="/static/favicon.svg" alt=""></a>',
         ),
     );
 });

--- a/svc/minidumpster/test/upload_test.ts
+++ b/svc/minidumpster/test/upload_test.ts
@@ -1,7 +1,9 @@
 import { assert, assertEquals } from '@std/assert';
+import { DatabaseSync } from 'node:sqlite';
 
 import { buildApp } from '../src/app.ts';
 import {
+    dbPath,
     dumpPath,
     processedPath,
     tmpDir,
@@ -40,7 +42,7 @@ Deno.test('pasted Apple crash reports are filed and deduped by incident id', asy
         form.append('text', await fixture());
         const res = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie: cookie },
+            headers: { cookie },
             body: form,
         });
         assertEquals(res.status, 302);
@@ -66,7 +68,7 @@ Deno.test('pasted Apple crash reports are filed and deduped by incident id', asy
         // Same incident again → redirected to the existing report.
         const again = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie: cookie },
+            headers: { cookie },
             body: (() => {
                 const f = new FormData();
                 f.append('text', stored);
@@ -75,6 +77,31 @@ Deno.test('pasted Apple crash reports are filed and deduped by incident id', asy
         });
         assertEquals(again.status, 302);
         assertEquals(again.headers.get('location'), `/reports/${id}`);
+
+        const legacyDb = new DatabaseSync(dbPath(env.dir));
+        try {
+            legacyDb.prepare(
+                `UPDATE reports
+                 SET status = 'failed', error = 'old failure', attempts = 5
+                 WHERE id = ?`,
+            ).run(id);
+        } finally {
+            legacyDb.close();
+        }
+
+        const retryForm = new FormData();
+        retryForm.append('text', stored);
+        const retry = await app.request('/upload', {
+            method: 'POST',
+            headers: { cookie },
+            body: retryForm,
+        });
+        assertEquals(retry.status, 302);
+        assertEquals(retry.headers.get('location'), `/reports/${id}`);
+        const requeued = env.db.getReport(id)!;
+        assertEquals(requeued.status, 'pending');
+        assertEquals(requeued.error, 'requeued by re-upload');
+        assertEquals(requeued.attempts, 0);
     } finally {
         await env.cleanup();
     }
@@ -90,7 +117,7 @@ Deno.test('upload rejects non-crash-report input and requires a session', async 
         form.append('text', '{"app_name":"Helium","bug_type":"309"}');
         const bad = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie: cookie },
+            headers: { cookie },
             body: form,
         });
         assertEquals(bad.status, 400);
@@ -119,7 +146,7 @@ Deno.test('manual upload streams without Content-Length and enforces UTF-8 bytes
         const ok = await app.request('/upload', {
             method: 'POST',
             headers: {
-                cookie: cookie,
+                cookie,
                 'content-type': encoded.contentType,
             },
             body: chunked(encoded.bytes, 17),
@@ -132,7 +159,7 @@ Deno.test('manual upload streams without Content-Length and enforces UTF-8 bytes
         const rejected = await app.request('/upload', {
             method: 'POST',
             headers: {
-                cookie: cookie,
+                cookie,
                 'content-type': tooLarge.contentType,
             },
             body: chunked(tooLarge.bytes, 11),
@@ -148,7 +175,7 @@ Deno.test('manual upload streams without Content-Length and enforces UTF-8 bytes
         );
         const fileRejected = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie: cookie },
+            headers: { cookie },
             body: oversizedFile,
         });
         assertEquals(fileRejected.status, 413);
@@ -171,7 +198,7 @@ Deno.test('manual upload removes the payload when database insertion fails', asy
         form.append('text', await fixture());
         const res = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie: cookie },
+            headers: { cookie },
             body: form,
         });
         assertEquals(res.status, 500);
@@ -216,7 +243,7 @@ Deno.test('authenticated report responses are not cached', async () => {
         env.db.markProcessed(id, group, 'macOS', Date.now(), true, 1);
 
         const initialPage = await app.request(`/reports/${id}`, {
-            headers: { cookie: cookie },
+            headers: { cookie },
         });
         const initialHtml = await initialPage.text();
         assertEquals(
@@ -230,14 +257,14 @@ Deno.test('authenticated report responses are not cached', async () => {
         );
 
         const dump = await app.request(`/reports/${id}/dump`, {
-            headers: { cookie: cookie },
+            headers: { cookie },
         });
         assertEquals(dump.status, 200);
         assertEquals(dump.headers.get('cache-control'), 'private, no-store');
         assertEquals(await dump.text(), 'raw');
 
         const processed = await app.request(`/reports/${id}/json`, {
-            headers: { cookie: cookie },
+            headers: { cookie },
         });
         assertEquals(processed.status, 200);
         assertEquals(
@@ -277,7 +304,7 @@ Deno.test('worker symbolicates Apple reports via /applecrashreport', async () =>
         form.append('text', await fixture());
         const res = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie: cookie },
+            headers: { cookie },
             body: form,
         });
         const id = res.headers.get('location')!.slice('/reports/'.length);
@@ -311,7 +338,7 @@ Deno.test('worker symbolicates Apple reports via /applecrashreport', async () =>
 
         // The report page shows product, version, and platform.
         const page = await app.request(`/reports/${id}`, {
-            headers: { cookie: cookie },
+            headers: { cookie },
         });
         assertEquals(page.status, 200);
         const html = await page.text();
@@ -343,14 +370,14 @@ Deno.test('search finds reports by id, id prefix, and guid', async () => {
         // Full id → direct redirect (case-insensitive).
         const byId = await app.request(
             `/search?q=${id.toUpperCase()}`,
-            { headers: { cookie: cookie } },
+            { headers: { cookie } },
         );
         assertEquals(byId.status, 302);
         assertEquals(byId.headers.get('location'), `/reports/${id}`);
 
         // 8-char prefix, as shown in the UI → redirect.
         const byPrefix = await app.request(`/search?q=${id.slice(0, 8)}`, {
-            headers: { cookie: cookie },
+            headers: { cookie },
         });
         assertEquals(byPrefix.status, 302);
         assertEquals(byPrefix.headers.get('location'), `/reports/${id}`);
@@ -358,21 +385,21 @@ Deno.test('search finds reports by id, id prefix, and guid', async () => {
         // Guid (lowercased by the user) → redirect.
         const byGuid = await app.request(
             `/search?q=${guid.toLowerCase()}`,
-            { headers: { cookie: cookie } },
+            { headers: { cookie } },
         );
         assertEquals(byGuid.status, 302);
         assertEquals(byGuid.headers.get('location'), `/reports/${id}`);
 
         // No match → results page, not an error.
         const none = await app.request('/search?q=ffffffff', {
-            headers: { cookie: cookie },
+            headers: { cookie },
         });
         assertEquals(none.status, 200);
         assert((await none.text()).includes('No reports match'));
 
         // Too-short queries are rejected.
         const short = await app.request('/search?q=ab', {
-            headers: { cookie: cookie },
+            headers: { cookie },
         });
         assertEquals(short.status, 400);
         await short.body?.cancel();

--- a/svc/minidumpster/test/upload_test.ts
+++ b/svc/minidumpster/test/upload_test.ts
@@ -1,20 +1,20 @@
 import { assert, assertEquals } from '@std/assert';
-import { serializeSigned } from 'hono/utils/cookie';
 
 import { buildApp } from '../src/app.ts';
-import { dumpPath } from '../src/paths.ts';
+import {
+    dumpPath,
+    processedPath,
+    tmpDir,
+    writeFileWithDirs,
+} from '../src/paths.ts';
 import { processReport } from '../src/worker.ts';
-import { makeTestEnv, type TestEnv } from './helpers.ts';
-
-async function sessionCookie(env: TestEnv): Promise<string> {
-    const value = JSON.stringify({ login: 'jj', exp: Date.now() + 60_000 });
-    const cookie = await serializeSigned(
-        'session',
-        value,
-        env.config.sessionSecret,
-    );
-    return cookie.split(';')[0];
-}
+import {
+    chunked,
+    dirEntries,
+    encodeMultipart,
+    makeTestEnv,
+    testSessionCookie,
+} from './helpers.ts';
 
 function fixture(): Promise<string> {
     return Deno.readTextFile(
@@ -35,12 +35,12 @@ Deno.test('pasted Apple crash reports are filed and deduped by incident id', asy
     const env = await makeTestEnv();
     try {
         const app = buildApp({ config: env.config, db: env.db });
-        const cookie = await sessionCookie(env);
+        const cookie = await testSessionCookie(env);
         const form = new FormData();
         form.append('text', await fixture());
         const res = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie },
+            headers: { cookie: cookie },
             body: form,
         });
         assertEquals(res.status, 302);
@@ -66,7 +66,7 @@ Deno.test('pasted Apple crash reports are filed and deduped by incident id', asy
         // Same incident again → redirected to the existing report.
         const again = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie },
+            headers: { cookie: cookie },
             body: (() => {
                 const f = new FormData();
                 f.append('text', stored);
@@ -84,13 +84,13 @@ Deno.test('upload rejects non-crash-report input and requires a session', async 
     const env = await makeTestEnv();
     try {
         const app = buildApp({ config: env.config, db: env.db });
-        const cookie = await sessionCookie(env);
+        const cookie = await testSessionCookie(env);
 
         const form = new FormData();
         form.append('text', '{"app_name":"Helium","bug_type":"309"}');
         const bad = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie },
+            headers: { cookie: cookie },
             body: form,
         });
         assertEquals(bad.status, 400);
@@ -104,43 +104,193 @@ Deno.test('upload rejects non-crash-report input and requires a session', async 
     }
 });
 
-Deno.test('worker symbolicates Apple reports via /applecrashreport', async () => {
-    const appleResponse = await appleFixtureResponse();
-    let normalizedSeen = '';
-    const server = Deno.serve(
-        { port: 0, onListen: () => {} },
-        async (req) => {
-            const url = new URL(req.url);
-            if (req.method === 'POST' && url.pathname === '/applecrashreport') {
-                const form = await req.formData();
-                const part = form.get('apple_crash_report');
-                normalizedSeen = part instanceof File ? await part.text() : '';
-                return new Response(appleResponse, {
-                    headers: { 'content-type': 'application/json' },
-                });
-            }
-            return new Response('wrong endpoint', { status: 404 });
-        },
-    );
-    const env = await makeTestEnv({
-        symbolicatorUrl: `http://127.0.0.1:${server.addr.port}`,
-    });
+Deno.test('manual upload streams without Content-Length and enforces UTF-8 bytes', async () => {
+    const fixtureText = await fixture();
+    const submitted = fixtureText.trim();
+    const normalized = submitted.replace(/\r?\n/g, '\r\n');
+    const fixtureBytes = new TextEncoder().encode(normalized).length;
+    const env = await makeTestEnv({ maxDumpSizeBytes: fixtureBytes });
     try {
         const app = buildApp({ config: env.config, db: env.db });
-        const cookie = await sessionCookie(env);
+        const cookie = await testSessionCookie(env);
+        const form = new FormData();
+        form.append('text', submitted);
+        const encoded = await encodeMultipart(form);
+        const ok = await app.request('/upload', {
+            method: 'POST',
+            headers: {
+                cookie: cookie,
+                'content-type': encoded.contentType,
+            },
+            body: chunked(encoded.bytes, 17),
+        });
+        assertEquals(ok.status, 302);
+
+        const oversized = new FormData();
+        oversized.append('text', `${submitted}é`);
+        const tooLarge = await encodeMultipart(oversized);
+        const rejected = await app.request('/upload', {
+            method: 'POST',
+            headers: {
+                cookie: cookie,
+                'content-type': tooLarge.contentType,
+            },
+            body: chunked(tooLarge.bytes, 11),
+        });
+        assertEquals(rejected.status, 413);
+        await rejected.body?.cancel();
+
+        const oversizedFile = new FormData();
+        oversizedFile.append(
+            'file',
+            new Blob([`${normalized}é`]),
+            'report.crash',
+        );
+        const fileRejected = await app.request('/upload', {
+            method: 'POST',
+            headers: { cookie: cookie },
+            body: oversizedFile,
+        });
+        assertEquals(fileRejected.status, 413);
+        await fileRejected.body?.cancel();
+        assertEquals(await dirEntries(tmpDir(env.dir)), []);
+    } finally {
+        await env.cleanup();
+    }
+});
+
+Deno.test('manual upload removes the payload when database insertion fails', async () => {
+    const env = await makeTestEnv();
+    try {
+        const app = buildApp({ config: env.config, db: env.db });
+        const cookie = await testSessionCookie(env);
+        env.db.insertReport = () => {
+            throw new Error('simulated database failure');
+        };
         const form = new FormData();
         form.append('text', await fixture());
         const res = await app.request('/upload', {
             method: 'POST',
-            headers: { cookie },
+            headers: { cookie: cookie },
+            body: form,
+        });
+        assertEquals(res.status, 500);
+        await res.body?.cancel();
+        for (const shard of await dirEntries(`${env.dir}/dumps`)) {
+            assertEquals(await dirEntries(`${env.dir}/dumps/${shard}`), []);
+        }
+        assertEquals(await dirEntries(tmpDir(env.dir)), []);
+    } finally {
+        await env.cleanup();
+    }
+});
+
+Deno.test('authenticated report responses are not cached', async () => {
+    const env = await makeTestEnv();
+    try {
+        const app = buildApp({ config: env.config, db: env.db });
+        const cookie = await testSessionCookie(env);
+        const id = crypto.randomUUID();
+        const receivedAt = Date.now();
+        const retentionDeadline = receivedAt
+            + env.config.retentionDays * 86_400_000;
+        const formattedDeadline = new Date(retentionDeadline).toISOString()
+            .replace('T', ' ').slice(0, 19) + ' UTC';
+        await writeFileWithDirs(dumpPath(env.dir, id), 'raw');
+        await writeFileWithDirs(processedPath(env.dir, id), '{}');
+        env.db.insertReport({
+            id,
+            product: 'Helium',
+            version: '1.0',
+            guid: 'incident',
+            ptype: null,
+            channel: null,
+            annotations: JSON.stringify({ uploaded_by: 'jj' }),
+            received_at: receivedAt,
+        });
+        const group = env.db.upsertGroup(
+            'retention-ui',
+            'retention',
+            Date.now(),
+        );
+        env.db.markProcessed(id, group, 'macOS', Date.now(), true, 1);
+
+        const initialPage = await app.request(`/reports/${id}`, {
+            headers: { cookie: cookie },
+        });
+        const initialHtml = await initialPage.text();
+        assertEquals(
+            initialPage.headers.get('cache-control'),
+            'private, no-store',
+        );
+        assert(
+            initialHtml.includes(
+                `This report will be automatically deleted at ${formattedDeadline}.`,
+            ),
+        );
+
+        const dump = await app.request(`/reports/${id}/dump`, {
+            headers: { cookie: cookie },
+        });
+        assertEquals(dump.status, 200);
+        assertEquals(dump.headers.get('cache-control'), 'private, no-store');
+        assertEquals(await dump.text(), 'raw');
+
+        const processed = await app.request(`/reports/${id}/json`, {
+            headers: { cookie: cookie },
+        });
+        assertEquals(processed.status, 200);
+        assertEquals(
+            processed.headers.get('cache-control'),
+            'private, no-store',
+        );
+        assertEquals(await processed.text(), '{}');
+    } finally {
+        await env.cleanup();
+    }
+});
+
+Deno.test('worker symbolicates Apple reports via /applecrashreport', async () => {
+    const appleResponse = await appleFixtureResponse();
+    let normalizedSeen = '';
+    const fetchFn = (async (
+        input: string | URL | Request,
+        init?: RequestInit,
+    ) => {
+        const url = new URL(String(input));
+        if (init?.method === 'POST' && url.pathname === '/applecrashreport') {
+            const form = init.body;
+            assert(form instanceof FormData);
+            const part = form.get('apple_crash_report');
+            normalizedSeen = part instanceof File ? await part.text() : '';
+            return new Response(appleResponse, {
+                headers: { 'content-type': 'application/json' },
+            });
+        }
+        return new Response('wrong endpoint', { status: 404 });
+    }) as typeof fetch;
+    const env = await makeTestEnv();
+    try {
+        const app = buildApp({ config: env.config, db: env.db });
+        const cookie = await testSessionCookie(env);
+        const form = new FormData();
+        form.append('text', await fixture());
+        const res = await app.request('/upload', {
+            method: 'POST',
+            headers: { cookie: cookie },
             body: form,
         });
         const id = res.headers.get('location')!.slice('/reports/'.length);
 
-        const [claimed] = env.db.claimPending(1, Date.now());
+        const claimed = env.db.claimNext(Date.now())!;
         assertEquals(claimed.id, id);
         await processReport(
-            { db: env.db, config: env.config, pollIntervalMs: 5 },
+            {
+                db: env.db,
+                config: env.config,
+                fetchFn,
+                pollIntervalMs: 5,
+            },
             claimed,
         );
 
@@ -161,14 +311,13 @@ Deno.test('worker symbolicates Apple reports via /applecrashreport', async () =>
 
         // The report page shows product, version, and platform.
         const page = await app.request(`/reports/${id}`, {
-            headers: { cookie },
+            headers: { cookie: cookie },
         });
         assertEquals(page.status, 200);
         const html = await page.text();
         assert(html.includes('Helium 0.14.3.1'));
         assert(html.includes('macOS'));
     } finally {
-        await server.shutdown();
         await env.cleanup();
     }
 });
@@ -177,7 +326,7 @@ Deno.test('search finds reports by id, id prefix, and guid', async () => {
     const env = await makeTestEnv();
     try {
         const app = buildApp({ config: env.config, db: env.db });
-        const cookie = await sessionCookie(env);
+        const cookie = await testSessionCookie(env);
         const id = crypto.randomUUID();
         const guid = 'D41D8CD9-8F00-B204-E980-0998ECF8427E';
         env.db.insertReport({
@@ -194,14 +343,14 @@ Deno.test('search finds reports by id, id prefix, and guid', async () => {
         // Full id → direct redirect (case-insensitive).
         const byId = await app.request(
             `/search?q=${id.toUpperCase()}`,
-            { headers: { cookie } },
+            { headers: { cookie: cookie } },
         );
         assertEquals(byId.status, 302);
         assertEquals(byId.headers.get('location'), `/reports/${id}`);
 
         // 8-char prefix, as shown in the UI → redirect.
         const byPrefix = await app.request(`/search?q=${id.slice(0, 8)}`, {
-            headers: { cookie },
+            headers: { cookie: cookie },
         });
         assertEquals(byPrefix.status, 302);
         assertEquals(byPrefix.headers.get('location'), `/reports/${id}`);
@@ -209,21 +358,21 @@ Deno.test('search finds reports by id, id prefix, and guid', async () => {
         // Guid (lowercased by the user) → redirect.
         const byGuid = await app.request(
             `/search?q=${guid.toLowerCase()}`,
-            { headers: { cookie } },
+            { headers: { cookie: cookie } },
         );
         assertEquals(byGuid.status, 302);
         assertEquals(byGuid.headers.get('location'), `/reports/${id}`);
 
         // No match → results page, not an error.
         const none = await app.request('/search?q=ffffffff', {
-            headers: { cookie },
+            headers: { cookie: cookie },
         });
         assertEquals(none.status, 200);
         assert((await none.text()).includes('No reports match'));
 
         // Too-short queries are rejected.
         const short = await app.request('/search?q=ab', {
-            headers: { cookie },
+            headers: { cookie: cookie },
         });
         assertEquals(short.status, 400);
         await short.body?.cancel();

--- a/svc/minidumpster/test/worker_test.ts
+++ b/svc/minidumpster/test/worker_test.ts
@@ -1,8 +1,13 @@
-import { assert, assertEquals } from '@std/assert';
+import { assert, assertEquals, assertRejects } from '@std/assert';
 
-import { processReport } from '../src/worker.ts';
+import { processReport, startWorker } from '../src/worker.ts';
 import { runRetention, runSymbolRetention } from '../src/retention.ts';
-import { fixtureResponse, makeTestEnv, type TestEnv } from './helpers.ts';
+import {
+    fixtureResponse,
+    makeTestEnv,
+    minimalMinidump,
+    type TestEnv,
+} from './helpers.ts';
 import { dumpPath, processedPath, writeFileWithDirs } from '../src/paths.ts';
 
 async function insertPendingReport(
@@ -12,7 +17,7 @@ async function insertPendingReport(
 ): Promise<void> {
     await writeFileWithDirs(
         dumpPath(env.dir, id),
-        new Uint8Array([0x4d, 0x44, 0x4d, 0x50, 1, 2, 3]),
+        minimalMinidump(),
     );
     env.db.insertReport({
         id,
@@ -26,54 +31,72 @@ async function insertPendingReport(
     });
 }
 
+async function assertFilesDoNotExist(...paths: string[]): Promise<void> {
+    for (const path of paths) {
+        await assertRejects(() => Deno.stat(path), Deno.errors.NotFound);
+    }
+}
+
+async function assertPayloadDiscarded(
+    env: TestEnv,
+    id: string,
+): Promise<void> {
+    assertEquals(env.db.getReport(id), null);
+    await assertFilesDoNotExist(
+        dumpPath(env.dir, id),
+        processedPath(env.dir, id),
+    );
+}
+
 /** Mock Symbolicator implementing the pending/poll protocol. */
 function mockSymbolicator(fixture: string, pendingPolls: number) {
     let polls = 0;
-    const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
-        const url = new URL(req.url);
-        if (req.method === 'POST' && url.pathname === '/minidump') {
-            return Response.json({
+    const fetchFn = ((input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (init?.method === 'POST' && url.pathname === '/minidump') {
+            return Promise.resolve(Response.json({
                 status: 'pending',
                 request_id: 'req-1',
                 retry_after: 0,
-            });
+            }));
         }
-        if (req.method === 'GET' && url.pathname === '/requests/req-1') {
+        if (url.pathname === '/requests/req-1') {
             polls++;
             if (polls <= pendingPolls) {
-                return Response.json({
+                return Promise.resolve(Response.json({
                     status: 'pending',
                     request_id: 'req-1',
                     retry_after: 0,
-                });
+                }));
             }
-            return new Response(fixture, {
-                headers: { 'content-type': 'application/json' },
-            });
+            return Promise.resolve(
+                new Response(fixture, {
+                    headers: { 'content-type': 'application/json' },
+                }),
+            );
         }
-        return new Response('not found', { status: 404 });
-    });
-    const addr = server.addr;
+        return Promise.resolve(new Response('not found', { status: 404 }));
+    }) as typeof fetch;
     return {
-        url: `http://127.0.0.1:${addr.port}`,
+        fetchFn,
         polls: () => polls,
-        shutdown: () => server.shutdown(),
     };
 }
 
 Deno.test('worker follows the pending/poll protocol and groups the report', async () => {
     const fixture = await fixtureResponse();
     const mock = mockSymbolicator(fixture, 2);
-    const env = await makeTestEnv({ symbolicatorUrl: mock.url });
+    const env = await makeTestEnv();
     try {
         await insertPendingReport(env, crypto.randomUUID());
-        const [claimed] = env.db.claimPending(1, Date.now());
+        const claimed = env.db.claimNext(Date.now());
         assert(claimed);
         assertEquals(env.db.getReport(claimed.id)!.status, 'processing');
 
         await processReport({
             db: env.db,
             config: env.config,
+            fetchFn: mock.fetchFn,
             pollIntervalMs: 5,
         }, claimed);
 
@@ -83,6 +106,8 @@ Deno.test('worker follows the pending/poll protocol and groups the report', asyn
         );
         const row = env.db.getReport(claimed.id)!;
         assertEquals(row.status, 'processed');
+        assertEquals(row.attempts, 1);
+        assertEquals(row.next_attempt_at, 0);
         assertEquals(row.platform, 'Windows');
         assert(row.group_id != null);
 
@@ -98,7 +123,100 @@ Deno.test('worker follows the pending/poll protocol and groups the report', asyn
         );
         assertEquals(processed.status, 'completed');
     } finally {
-        await mock.shutdown();
+        await env.cleanup();
+    }
+});
+
+Deno.test('worker shutdown wakes idle polling and aborts symbolication', async () => {
+    const env = await makeTestEnv({ workerPollMs: 60_000 });
+    try {
+        const idle = startWorker({ db: env.db, config: env.config });
+        const idleStarted = performance.now();
+        await idle.stop();
+        assert(performance.now() - idleStarted < 1000);
+
+        const id = crypto.randomUUID();
+        await insertPendingReport(env, id);
+        const { promise: started, resolve: notifyStarted } = Promise
+            .withResolvers<void>();
+        let requests = 0;
+        const fetchFn =
+            ((_input: string | URL | Request, init?: RequestInit) => {
+                requests++;
+                notifyStarted();
+                return new Promise<Response>((_resolve, reject) => {
+                    const signal = init?.signal;
+                    if (signal?.aborted) {
+                        reject(signal.reason);
+                        return;
+                    }
+                    signal?.addEventListener(
+                        'abort',
+                        () => reject(signal.reason),
+                        { once: true },
+                    );
+                });
+            }) as typeof fetch;
+        const abort = new AbortController();
+        const active = startWorker({
+            db: env.db,
+            config: env.config,
+            fetchFn,
+            signal: abort.signal,
+        });
+        await started;
+        const activeStarted = performance.now();
+        abort.abort();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        assertEquals(requests, 1);
+        await active.stop();
+        assert(performance.now() - activeStarted < 1000);
+        const row = env.db.getReport(id)!;
+        assertEquals(row.status, 'pending');
+        assertEquals(row.attempts, 0);
+        assertEquals(row.next_attempt_at, 0);
+    } finally {
+        await env.cleanup();
+    }
+});
+
+Deno.test('worker survives a secondary report-state write failure', async () => {
+    const completed = await fixtureResponse();
+    let requests = 0;
+    const fetchFn = (() =>
+        Promise.resolve(
+            requests++ === 0
+                ? new Response('temporary failure', { status: 500 })
+                : new Response(completed, {
+                    headers: { 'content-type': 'application/json' },
+                }),
+        )) as typeof fetch;
+    const env = await makeTestEnv({ workerPollMs: 5 });
+    try {
+        const id = crypto.randomUUID();
+        await insertPendingReport(env, id);
+        const markRetry = env.db.markRetry.bind(env.db);
+        let failOnce = true;
+        env.db.markRetry = (...args) => {
+            if (failOnce) {
+                failOnce = false;
+                throw new Error('simulated state write failure');
+            }
+            markRetry(...args);
+        };
+
+        const worker = startWorker({ db: env.db, config: env.config, fetchFn });
+        const deadline = Date.now() + 1000;
+        while (
+            env.db.getReport(id)?.status !== 'processed'
+            && Date.now() < deadline
+        ) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        await worker.stop();
+        assertEquals(env.db.getReport(id)?.status, 'processed');
+        assertEquals(requests, 2);
+    } finally {
         await env.cleanup();
     }
 });
@@ -106,16 +224,19 @@ Deno.test('worker follows the pending/poll protocol and groups the report', asyn
 Deno.test('two crashes with the same stack land in the same group', async () => {
     const fixture = await fixtureResponse();
     const mock = mockSymbolicator(fixture, 0);
-    const env = await makeTestEnv({ symbolicatorUrl: mock.url });
+    const env = await makeTestEnv();
     try {
         await insertPendingReport(env, crypto.randomUUID());
         await insertPendingReport(env, crypto.randomUUID());
-        const claimed = env.db.claimPending(10, Date.now());
-        assertEquals(claimed.length, 2);
+        const claimed = [
+            env.db.claimNext(Date.now())!,
+            env.db.claimNext(Date.now())!,
+        ];
         for (const r of claimed) {
             await processReport({
                 db: env.db,
                 config: env.config,
+                fetchFn: mock.fetchFn,
                 pollIntervalMs: 5,
             }, r);
         }
@@ -124,31 +245,41 @@ Deno.test('two crashes with the same stack land in the same group', async () => 
         assertEquals(a.group_id, b.group_id);
         assertEquals(env.db.getGroup(a.group_id!)!.report_count, 2);
     } finally {
-        await mock.shutdown();
         await env.cleanup();
     }
 });
 
-Deno.test('worker retries with backoff, then marks the report failed', async () => {
-    const server = Deno.serve(
-        { port: 0, onListen: () => {} },
-        () => new Response('boom', { status: 500 }),
-    );
-    const addr = server.addr;
+Deno.test('worker retries with backoff, then discards terminal failures', async () => {
+    const fetchFn = (() =>
+        Promise.resolve(
+            new Response('boom', { status: 500 }),
+        )) as typeof fetch;
     const env = await makeTestEnv({
-        symbolicatorUrl: `http://127.0.0.1:${addr.port}`,
         maxAttempts: 2,
     });
     try {
-        await insertPendingReport(env, crypto.randomUUID());
-        const [first] = env.db.claimPending(1, Date.now());
+        const id = crypto.randomUUID();
+        await insertPendingReport(env, id);
+        const group = env.db.upsertGroup(
+            'terminal-failure',
+            'terminal',
+            Date.now(),
+        );
+        env.db.markProcessed(id, group, 'Windows', Date.now(), false, 1);
+        env.db.recountGroups([group]);
+        assertEquals(
+            env.db.requeueUnsymbolicated('MyBrowser', '138.0.1.0', 0),
+            1,
+        );
+        const first = env.db.claimNext(Date.now())!;
         await processReport({
             db: env.db,
             config: env.config,
+            fetchFn,
             pollIntervalMs: 5,
         }, first);
 
-        let row = env.db.getReport(first.id)!;
+        const row = env.db.getReport(first.id)!;
         assertEquals(row.status, 'pending');
         assertEquals(row.attempts, 1);
         assert(row.error && row.error.includes('500'));
@@ -157,52 +288,151 @@ Deno.test('worker retries with backoff, then marks the report failed', async () 
             'retry should be scheduled in the future',
         );
         assertEquals(
-            env.db.claimPending(1, Date.now()).length,
-            0,
+            env.db.claimNext(Date.now()),
+            null,
             'not claimable before backoff elapses',
         );
 
-        const [second] = env.db.claimPending(1, row.next_attempt_at + 1);
+        const second = env.db.claimNext(row.next_attempt_at + 1);
         assert(second);
+        await writeFileWithDirs(
+            processedPath(env.dir, first.id),
+            '{"sensitive":"partial result"}',
+        );
         await processReport({
             db: env.db,
             config: env.config,
+            fetchFn,
             pollIntervalMs: 5,
         }, second);
-        row = env.db.getReport(first.id)!;
-        assertEquals(row.status, 'failed');
-        assertEquals(row.attempts, 2);
+        await assertPayloadDiscarded(env, first.id);
+        assertEquals(env.db.getGroup(group), null);
+        assertEquals(env.db.reportsPerDay(0), []);
     } finally {
-        await server.shutdown();
         await env.cleanup();
     }
 });
 
-Deno.test('retention deletes old dumps but keeps metadata', async () => {
+Deno.test('worker drops raw data rejected by Symbolicator parsing', async () => {
+    let requests = 0;
+    const fetchFn = (() => {
+        requests++;
+        return Promise.resolve(Response.json({
+            status: 'failed',
+            message: 'malformed minidump with sensitive details',
+        }));
+    }) as typeof fetch;
+    const env = await makeTestEnv({
+        maxAttempts: 5,
+    });
+    try {
+        const id = crypto.randomUUID();
+        await writeFileWithDirs(dumpPath(env.dir, id), new Uint8Array([1]));
+        await writeFileWithDirs(
+            processedPath(env.dir, id),
+            '{"sensitive":"old processing result"}',
+        );
+        env.db.insertReport({
+            id,
+            product: 'MyBrowser',
+            version: '1.0',
+            guid: 'sensitive-guid',
+            ptype: 'renderer',
+            channel: 'stable',
+            annotations: JSON.stringify({ uploaded_by: 'jj', secret: 'x' }),
+            received_at: Date.now(),
+        });
+        const group = env.db.upsertGroup(
+            'rejected',
+            'rejected',
+            Date.now(),
+        );
+        env.db.markProcessed(id, group, 'Windows', Date.now(), false, 1);
+        env.db.recountGroups([group]);
+        assertEquals(
+            env.db.requeueUnsymbolicated('MyBrowser', '1.0', 0),
+            1,
+        );
+        const claimed = env.db.claimNext(Date.now())!;
+        await processReport(
+            {
+                db: env.db,
+                config: env.config,
+                fetchFn,
+                pollIntervalMs: 5,
+            },
+            claimed,
+        );
+
+        await assertPayloadDiscarded(env, id);
+        assertEquals(env.db.getGroup(group), null);
+        assertEquals(env.db.reportsPerDay(0), []);
+        assertEquals(requests, 1);
+        assertEquals(env.db.claimNext(Number.MAX_SAFE_INTEGER), null);
+    } finally {
+        await env.cleanup();
+    }
+});
+
+Deno.test('retention deletes expired reports and all of their files', async () => {
     const env = await makeTestEnv({ retentionDays: 30 });
+    const now = Date.now();
+    const old = now - 31 * 24 * 60 * 60 * 1000;
     try {
         const oldId = crypto.randomUUID();
         const newId = crypto.randomUUID();
-        // The old report predates the retention window.
-        await insertPendingReport(
-            env,
-            oldId,
-            Date.now() - 31 * 24 * 60 * 60 * 1000,
-        );
+        await writeFileWithDirs(dumpPath(env.dir, oldId), 'sensitive dump');
+        await writeFileWithDirs(processedPath(env.dir, oldId), '{}');
+        env.db.insertReport({
+            id: oldId,
+            product: 'MyBrowser',
+            version: '1.0',
+            guid: 'sensitive-guid',
+            ptype: 'renderer',
+            channel: 'stable',
+            annotations: JSON.stringify({
+                uploaded_by: 'jj',
+                secret: 'annotation',
+            }),
+            received_at: old,
+        });
         await insertPendingReport(env, newId);
+        const group = env.db.upsertGroup('retention-test', 'retention', old);
+        env.db.markProcessed(oldId, group, 'Windows', old, true, 1);
 
-        const deleted = await runRetention(env.db, env.config);
-        assertEquals(deleted, 1);
-        assertEquals(env.db.getReport(oldId)!.dump_deleted, 1);
-        assertEquals(env.db.getReport(newId)!.dump_deleted, 0);
-        await Deno.stat(dumpPath(env.dir, newId)); // still there
-        let gone = false;
-        try {
-            await Deno.stat(dumpPath(env.dir, oldId));
-        } catch {
-            gone = true;
-        }
-        assert(gone, 'old dump file should be removed');
+        assertEquals(runRetention(env.db, env.config, now), 1);
+        assertEquals(env.db.getReport(oldId), null);
+        assertEquals(env.db.getGroup(group), null);
+        assert(env.db.getReport(newId));
+        await Deno.stat(dumpPath(env.dir, newId));
+        await assertFilesDoNotExist(
+            dumpPath(env.dir, oldId),
+            processedPath(env.dir, oldId),
+        );
+    } finally {
+        await env.cleanup();
+    }
+});
+
+Deno.test('retention skips active workers and deletes rows before files', async () => {
+    const env = await makeTestEnv({ retentionDays: 30 });
+    const now = Date.now();
+    const old = now - 31 * 24 * 60 * 60 * 1000;
+    try {
+        const id = crypto.randomUUID();
+        await insertPendingReport(env, id, old);
+        const claimed = env.db.claimNext(now)!;
+        assertEquals(claimed.id, id);
+        assertEquals(env.db.getReport(id)?.status, 'processing');
+
+        assertEquals(runRetention(env.db, env.config, now), 0);
+        assertEquals(env.db.getReport(id)?.status, 'processing');
+        await Deno.stat(dumpPath(env.dir, id));
+
+        env.db.markRetry(id, 'requeued after processing', 1, 0);
+        assertEquals(runRetention(env.db, env.config, now), 1);
+        assertEquals(env.db.getReport(id), null);
+        await assertFilesDoNotExist(dumpPath(env.dir, id));
     } finally {
         await env.cleanup();
     }
@@ -244,16 +474,13 @@ Deno.test('symbols upload requeues unsymbolicated reports, which then regroup', 
         }],
     });
     let withSymbols = false;
-    const server = Deno.serve(
-        { port: 0, onListen: () => {} },
-        () =>
+    const fetchFn = (() =>
+        Promise.resolve(
             new Response(withSymbols ? symbolicated : unsymbolicated, {
                 headers: { 'content-type': 'application/json' },
             }),
-    );
-    const env = await makeTestEnv({
-        symbolicatorUrl: `http://127.0.0.1:${server.addr.port}`,
-    });
+        )) as typeof fetch;
+    const env = await makeTestEnv();
     try {
         const id = crypto.randomUUID();
         await writeFileWithDirs(dumpPath(env.dir, id), new Uint8Array([1]));
@@ -267,14 +494,20 @@ Deno.test('symbols upload requeues unsymbolicated reports, which then regroup', 
             annotations: '{}',
             received_at: Date.now(),
         });
-        const [first] = env.db.claimPending(1, Date.now());
+        const first = env.db.claimNext(Date.now())!;
         await processReport(
-            { db: env.db, config: env.config, pollIntervalMs: 5 },
+            {
+                db: env.db,
+                config: env.config,
+                fetchFn,
+                pollIntervalMs: 5,
+            },
             first,
         );
         let row = env.db.getReport(id)!;
         assertEquals(row.status, 'processed');
         assertEquals(row.symbolicated, 0);
+        await Deno.stat(dumpPath(env.dir, id));
         const junkGroupId = row.group_id!;
 
         // Symbols arrive (product name cased differently, as CI would send).
@@ -285,16 +518,21 @@ Deno.test('symbols upload requeues unsymbolicated reports, which then regroup', 
         );
         assertEquals(env.db.getReport(id)!.status, 'pending');
         assertEquals(
-            env.db.claimPending(1, Date.now()).length,
-            0,
+            env.db.claimNext(Date.now()),
+            null,
             'not claimable before the negative-cache delay',
         );
 
         withSymbols = true;
-        const [second] = env.db.claimPending(1, notBefore + 1);
+        const second = env.db.claimNext(notBefore + 1);
         assert(second);
         await processReport(
-            { db: env.db, config: env.config, pollIntervalMs: 5 },
+            {
+                db: env.db,
+                config: env.config,
+                fetchFn,
+                pollIntervalMs: 5,
+            },
             second,
         );
         row = env.db.getReport(id)!;
@@ -317,7 +555,6 @@ Deno.test('symbols upload requeues unsymbolicated reports, which then regroup', 
             0,
         );
     } finally {
-        await server.shutdown();
         await env.cleanup();
     }
 });

--- a/svc/minidumpster/test/zip_test.ts
+++ b/svc/minidumpster/test/zip_test.ts
@@ -1,28 +1,8 @@
 import { join } from '@std/path';
 import { assert, assertEquals } from '@std/assert';
-import {
-    BlobWriter,
-    TextReader,
-    Uint8ArrayReader,
-    ZipWriter,
-} from '@zip-js/zip-js';
 
 import { extractZip } from '../src/zip.ts';
-
-async function makeZip(
-    entries: [string, Uint8Array | string][],
-): Promise<Uint8Array> {
-    const writer = new ZipWriter(new BlobWriter('application/zip'));
-    for (const [name, data] of entries) {
-        await writer.add(
-            name,
-            typeof data === 'string'
-                ? new TextReader(data)
-                : new Uint8ArrayReader(data),
-        );
-    }
-    return new Uint8Array(await (await writer.close()).arrayBuffer());
-}
+import { makeZip } from './helpers.ts';
 
 Deno.test('extractZip preserves nested paths (dSYM-style bundles)', async () => {
     const dir = await Deno.makeTempDir();


### PR DESCRIPTION
### ingest & processing

- report claims are atomic; interrupted work is reset on startup and worker errors no longer kill the processing loop
- symbolicator submits and polls share a hard deadline; shutdown aborts in-flight work and requeues the report without burning a retry
- reports rejected by symbolicator or exhausting retries are removed instead of sticking around as failed
- failed db inserts clean up the dump that was just written
- upstream symbolicator errors are logged server-side without leaking response bodies to clients

### retention & privacy

- retention removes expired report rows, recounts affected groups, then deletes both raw and processed payloads
- report pages show when the report will be deleted
- crash ingest logs no longer include product, version, process type or channel
- runtime data is gitignored
- readme now documents 30-day raw + derived data retention and trusted `X-Forwarded-For` setup

### web & auth

- add csp, frame, referrer and cross-origin headers; hsts when served over https
- don't cache auth responses or private report pages
- add logo + mobile header; move frame expansion js into a csp-safe static asset
- count manual apple report uploads in utf-8 bytes and deduplicate them by incident id
- only expose processed json once processing is complete

### symbols & artifacts

- cap streamed multipart symbol uploads at 16 mib and fields at 64 kib
- validate product/version names before running symsorter; kill symsorter after 30 minutes
- resume interrupted build artifact downloads and reject responses that exceed github's declared size
- ingest macos `build_src.tar.zst` and windows `artifacts.zip` archives into the symbol store

### misc

- fix arm64 docker builds by using buildkit's `TARGETARCH`
- ignore repeated shutdown signals
- simplify crash signature hashing