### PR TITLE
svc/nginx: drop /updates/mac proxy endpoint

### DIFF
--- a/svc/nginx/nginx.conf.j2
+++ b/svc/nginx/nginx.conf.j2
@@ -119,10 +119,6 @@ http {
             return 204;
         }
 
-        location /updates/mac {
-            proxy_pass https://updates.helium.computer/mac;
-        }
-
         location /dict {
             gzip_static always;
             root /dev/shm/dictionaries;


### PR DESCRIPTION
updates have been routed directly to updates.helium.computer since imputnet/helium@c6a41202cec, so i think it's safe to drop here now