### PR TITLE
svc/minidumpster/css: fix code line break

### DIFF
--- a/svc/minidumpster/src/static/style.css
+++ b/svc/minidumpster/src/static/style.css
@@ -25,6 +25,7 @@ code,
 .mono {
     font-family: ui-monospace, monospace;
     font-size: .92em;
+    line-break: anywhere;
 }
 
 header {


### PR DESCRIPTION
prevents traces from overlapping or overstretching other columns

before:
<img width="1187" height="395" alt="image" src="https://github.com/user-attachments/assets/765332a2-b290-4ad0-9fa1-4c8debbabf98" />

after:
<img width="1138" height="269" alt="image" src="https://github.com/user-attachments/assets/9b1d9cb4-7c4d-4ef9-84fa-ef213ad5361c" />
